### PR TITLE
UI restore

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -7,7 +7,7 @@ const webpack = require('webpack');
 
 const localPath = (...args) => path.resolve(__dirname, ...args);
 
-module.exports = (env, argv) => merge(common(env, argv), {
+module.exports = (env, argv) => merge(common.config(env, argv), {
   devtool: 'inline-source-map',
   devServer: {
     contentBase: '/dist',

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -6,12 +6,13 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 const localPath = (...args) => path.resolve(__dirname, ...args);
 
-module.exports = (env, argv) => merge(common(env, argv), {
+module.exports = (env, argv) => merge(common.config(env, argv), {
+  output: {
+    path: common.BUILD_DIR,
+    publicPath: './',
+    filename: '[name].bundle.js',
+  },
   plugins: [
-     new webpack.optimize.UglifyJsPlugin({
-      sourceMap: true,
-      parallel: true // will use an optimal number of CPUs
-    }),
     new ForkTsCheckerWebpackPlugin({
       async: false,
       watch: localPath('src'),

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -13,6 +13,7 @@ import {IEditorState, IEditorProps, IEditorForm} from './interfaces';
 import { DraggableWidget } from 'components/widget';
 import { hideEditor } from 'store/widgets/actions';
 import {createAnnotation} from '../../store/annotations/actions';
+import {Range} from 'xpath-range';
 
 @connect(
   (state) => {
@@ -20,6 +21,7 @@ import {createAnnotation} from '../../store/annotations/actions';
       visible,
       locationX,
       locationY,
+      range,
       // form
       annotationId,
       priority,
@@ -32,6 +34,7 @@ import {createAnnotation} from '../../store/annotations/actions';
       visible,
       locationX,
       locationY,
+      range,
       // form
       annotationId,
       priority,
@@ -42,8 +45,11 @@ import {createAnnotation} from '../../store/annotations/actions';
   },
   dispatch => ({
     hideEditor: () => dispatch(hideEditor()),
-    createAnnotation: (form: IEditorForm) => {
-      dispatch(createAnnotation(form));
+    createAnnotation: (form: IEditorForm, range: Range.SerializedRange) => {
+      dispatch(createAnnotation({
+        ...form,
+        range,
+      }));
     },
   }),
 )
@@ -170,7 +176,7 @@ class Editor extends React.Component<
   save() {
     // TODO provide real query promise; for now just a placeholder (createAnnotation is to be removed)
     const fetchData = new Promise((resolve, reject) => {
-      this.props.createAnnotation(this.state);
+      this.props.createAnnotation(this.state, this.props.range);
       resolve();
     });
 

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -66,6 +66,7 @@ class Editor extends React.Component<
       referenceLink: nextProps.referenceLink,
       referenceLinkTitle: nextProps.referenceLinkTitle,
 
+      moved: false,
       locationX: nextProps.locationX,
       locationY: nextProps.locationY,
       referenceLinkError: '',
@@ -84,6 +85,15 @@ class Editor extends React.Component<
 
   isNewAnnotation() {
     return this.props.annotationId !== null;
+  }
+
+  onDrag = (delta: IVec2) => {
+    this.setState({
+      locationX: this.state.locationX + delta.x,
+      locationY: this.state.locationY + delta.y,
+      moved: true,
+    });
+    return true;
   }
 
   setPriority = (priority: AnnotationPriorities) => {
@@ -181,6 +191,7 @@ class Editor extends React.Component<
     const {
       locationX,
       locationY,
+      moved,
       priority,
       comment,
       referenceLink,
@@ -200,6 +211,8 @@ class Editor extends React.Component<
         locationX={locationX}
         locationY={locationY}
         mover={this.moverElement}
+        onDrag={this.onDrag}
+        calculateInverted={!moved}
       >
         <div className={styles.headBar}>
           <label className={styles.priorityHeader}> Co dodajesz? </label>

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -176,7 +176,7 @@ class Editor extends React.Component<
   save() {
     // TODO provide real query promise; for now just a placeholder (createAnnotation is to be removed)
     const fetchData = new Promise((resolve, reject) => {
-      this.props.createAnnotation(this.state, this.props.range);
+      this.props.createAnnotation(this.state as IEditorForm, this.props.range);
       resolve();
     });
 

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1,19 +1,17 @@
 import React, {RefObject} from 'react';
 import {connect} from 'react-redux';
 import classNames from 'classnames';
-import {selectEditorState} from 'store/selectors';
-
-import {AnnotationPriorities, annotationPrioritiesLabels} from '../consts';
-import styles from './Editor.scss';
-import {DragTracker, IVec2} from '../../utils/move';
-import PriorityButton from './priority-button/PriorityButton';
+import {Range} from 'xpath-range';
 import {Modal, Popup} from 'semantic-ui-react';
-import Widget from '../widget/Widget';
+import {AnnotationPriorities, annotationPrioritiesLabels} from '../consts';
+import {DragTracker, IVec2} from 'utils/move';
+import PriorityButton from './priority-button/PriorityButton';
 import {IEditorState, IEditorProps, IEditorForm} from './interfaces';
 import { DraggableWidget } from 'components/widget';
-import { hideEditor } from 'store/widgets/actions';
-import {createAnnotation} from '../../store/annotations/actions';
-import {Range} from 'xpath-range';
+import { hideEditor, createAnnotation} from 'store/actions';
+import {selectEditorState} from 'store/selectors';
+
+import styles from './Editor.scss';
 
 @connect(
   (state) => {

--- a/src/components/editor/interfaces.ts
+++ b/src/components/editor/interfaces.ts
@@ -11,16 +11,8 @@ export interface IEditorForm {
 
 export interface IEditorProps extends IEditorForm {
   visible: boolean;
-  invertedX: boolean;
-  invertedY: boolean;
   locationX: number;
   locationY: number;
-  /*
-   * calculateInverted - (overwrites invertedX and invertedY)
-   * if true, the widget horizontal or vertical inversion will be calculated based on the window location
-   * after the component is rendered for the first time after prop change
-   */
-  editor: any;
   range: Range.SerializedRange;
 
   createAnnotation: (IEditorForm) => void;

--- a/src/components/editor/interfaces.ts
+++ b/src/components/editor/interfaces.ts
@@ -19,16 +19,14 @@ export interface IEditorProps extends IEditorForm {
    * if true, the widget horizontal or vertical inversion will be calculated based on the window location
    * after the component is rendered for the first time after prop change
    */
-  calculateInverted: boolean;
   editor: any;
 }
 
 export interface IEditorState extends IEditorForm {
   locationX: number;
   locationY: number;
-  calculateInverted: boolean;
+  moved: boolean;
 
-  isDragged: boolean;
   noCommentModalOpen: boolean;
 
   referenceLinkError: string;

--- a/src/components/editor/interfaces.ts
+++ b/src/components/editor/interfaces.ts
@@ -15,7 +15,7 @@ export interface IEditorProps extends IEditorForm {
   locationY: number;
   range: Range.SerializedRange;
 
-  createAnnotation: (IEditorForm) => void;
+  createAnnotation: (form: IEditorForm, range: Range.SerializedRange) => void;
   hideEditor: () => void;
 }
 

--- a/src/components/editor/interfaces.ts
+++ b/src/components/editor/interfaces.ts
@@ -1,0 +1,36 @@
+import {AnnotationPriorities} from '../consts';
+
+export interface IEditorForm {
+  annotationId: number;
+  priority: AnnotationPriorities;
+  comment: string;
+  referenceLink: string;
+  referenceLinkTitle: string;
+}
+
+export interface IEditorProps extends IEditorForm {
+  visible: boolean;
+  invertedX: boolean;
+  invertedY: boolean;
+  locationX: number;
+  locationY: number;
+  /*
+   * calculateInverted - (overwrites invertedX and invertedY)
+   * if true, the widget horizontal or vertical inversion will be calculated based on the window location
+   * after the component is rendered for the first time after prop change
+   */
+  calculateInverted: boolean;
+  editor: any;
+}
+
+export interface IEditorState extends IEditorForm {
+  locationX: number;
+  locationY: number;
+  calculateInverted: boolean;
+
+  isDragged: boolean;
+  noCommentModalOpen: boolean;
+
+  referenceLinkError: string;
+  referenceLinkTitleError: string;
+}

--- a/src/components/editor/interfaces.ts
+++ b/src/components/editor/interfaces.ts
@@ -1,4 +1,5 @@
 import {AnnotationPriorities} from '../consts';
+import {Range} from 'xpath-range';
 
 export interface IEditorForm {
   annotationId: number;
@@ -20,6 +21,8 @@ export interface IEditorProps extends IEditorForm {
    * after the component is rendered for the first time after prop change
    */
   editor: any;
+  range: Range.SerializedRange;
+
   createAnnotation: (IEditorForm) => void;
   hideEditor: () => void;
 }

--- a/src/components/editor/interfaces.ts
+++ b/src/components/editor/interfaces.ts
@@ -20,6 +20,8 @@ export interface IEditorProps extends IEditorForm {
    * after the component is rendered for the first time after prop change
    */
   editor: any;
+  createAnnotation: (IEditorForm) => void;
+  hideEditor: () => void;
 }
 
 export interface IEditorState extends IEditorForm {

--- a/src/components/highlights/Highlights.ts
+++ b/src/components/highlights/Highlights.ts
@@ -1,0 +1,59 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import {Highlighter} from 'core';
+import {showViewer} from 'store/widgets/actions';
+import { mousePosition } from 'common/dom';
+
+interface IHighlightsProps {
+  annotations: any[];
+  showViewer: (x: number, y: number, annotationId: number) => void;
+}
+
+@connect(
+  state => ({
+    annotations: state.annotations.data,
+  }),
+  dispatch => ({
+    showViewer: (x, y, annotationId) => dispatch(showViewer(x, y, annotationId)),
+  }),
+)
+export default class Highlights extends React.Component<Partial<IHighlightsProps>, {}> {
+  highlighter: Highlighter;
+
+  constructor(props: IHighlightsProps) {
+    super(props);
+    this.highlighter = new Highlighter(document.body);
+    // This event subscription will last irrespective of whether annotations are redrawn or not
+    this.highlighter.onHighlightEvent('mouseover', this.showViewer);
+  }
+
+  showViewer = (e, annotations) => {
+    const position = mousePosition(e);
+    this.props.showViewer(
+      position.x,
+      position.y,
+      annotations.map(annotation => annotation.annotationId),
+    );
+  }
+
+  drawAll() {
+    // For each annotation, it is cleared and drawn again
+    this.highlighter.drawAll(this.props.annotations.map(annotation => ({
+      id: annotation.annotationId,
+      range: annotation.range,
+      annotationData: annotation,
+    })));
+  }
+
+  componentDidMount() {
+    this.drawAll();
+  }
+
+  componentDidUpdate() {
+    this.drawAll();
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -8,13 +8,15 @@ import Widget from 'components/widget';
 
 import styles from './Menu.scss';
 import {hideMenu, showEditorNewAnnotation} from 'store/widgets/actions';
+import {Range} from 'xpath-range';
 
 interface IMenuProps {
   visible: boolean;
   locationX: number;
   locationY: number;
+  range: Range.SerializedRange;
 
-  showEditor: (x: number, y: number) => void;
+  showEditor: (x: number, y: number, range: Range.SerializedRange) => void;
   hideMenu: () => void;
 }
 
@@ -30,10 +32,11 @@ interface IMenuProps {
     visible,
     locationX,
     locationY,
+    range: state.textSelector.range,
   };
 },
   dispatch => ({
-    showEditor: (x, y) => dispatch(showEditorNewAnnotation(x, y)),
+    showEditor: (x, y, range) => dispatch(showEditorNewAnnotation(x, y, range)),
     hideMenu: () => dispatch(hideMenu()),
   }),
 )
@@ -50,9 +53,14 @@ export default class Menu extends React.Component<Partial<IMenuProps>, {}> {
   }
 
   onClick = (e: any) => {
-    console.log('heeej');
+    const {
+      locationX,
+      locationY,
+      range,
+    } = this.props;
+
     this.props.hideMenu();
-    this.props.showEditor(this.props.locationX, this.props.locationY);
+    this.props.showEditor(locationX, locationY, range);
   }
 
   render() {

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -7,14 +7,19 @@ import { selectMenuState } from 'store/selectors';
 import Widget from 'components/widget';
 
 import styles from './Menu.scss';
+import {hideMenu, showEditorNewAnnotation} from 'store/widgets/actions';
 
 interface IMenuProps {
   visible: boolean;
   locationX: number;
   locationY: number;
+
+  showEditor: (x: number, y: number) => void;
+  hideMenu: () => void;
 }
 
-@connect((state) => {
+@connect(
+  (state) => {
   const {
     visible,
     locationX,
@@ -26,7 +31,12 @@ interface IMenuProps {
     locationX,
     locationY,
   };
-})
+},
+  dispatch => ({
+    showEditor: (x, y) => dispatch(showEditorNewAnnotation(x, y)),
+    hideMenu: () => dispatch(hideMenu()),
+  }),
+)
 export default class Menu extends React.Component<Partial<IMenuProps>, {}> {
 
   static defaultProps = {
@@ -39,9 +49,10 @@ export default class Menu extends React.Component<Partial<IMenuProps>, {}> {
     super(props);
   }
 
-  onClick(event: any) {
-    // TODO
-    console.log(event);
+  onClick = (e: any) => {
+    console.log('heeej');
+    this.props.hideMenu();
+    this.props.showEditor(this.props.locationX, this.props.locationY);
   }
 
   render() {

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -1,29 +1,43 @@
 import React from 'react';
 import classNames from 'classnames';
-
+import { connect } from 'react-redux';
 import Widget from 'components/widget';
-import AnnotationViewModel from 'models/AnnotationViewModel';
 
 import ViewerItem from './ViewerItem';
 import styles from './Viewer.scss';
+import {selectViewerState} from 'store/widgets/selectors';
 
 interface IViewerProps {
   visible: boolean;
-  invertedX: boolean;
-  invertedY: boolean;
   locationX: number;
   locationY: number;
-  annotations: AnnotationViewModel[];
+  annotations: any[];
 }
 
+@connect(
+  (state) => {
+    const {
+      visible,
+      locationX,
+      locationY,
+      annotations,
+    } = selectViewerState(state);
+
+    return {
+      visible,
+      locationX,
+      locationY,
+      annotations,
+    };
+  },
+)
 export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
 
   static defaultProps = {
     visible: true,
-    invertedX: false,
-    invertedY: false,
     locationX: 0,
     locationY: 0,
+    annotations: [],
   };
 
   constructor(props: IViewerProps) {
@@ -33,7 +47,7 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
   renderItems() {
     return this.props.annotations.map(annotation => (
       <ViewerItem
-        key={annotation.id}
+        key={annotation.annotationId}
         annotation={annotation}
       />
     ));
@@ -44,10 +58,9 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
       <Widget
         className={classNames('pp-ui', styles.self)}
         visible={this.props.visible}
-        invertedX={this.props.invertedX}
-        invertedY={this.props.invertedY}
         locationX={this.props.locationX}
         locationY={this.props.locationY}
+        calculateInverted={true}
       >
         <ul className={styles.annotationItems}>
           {this.renderItems()}

--- a/src/components/widget/DraggableWidget.tsx
+++ b/src/components/widget/DraggableWidget.tsx
@@ -83,6 +83,6 @@ export default class DraggableWidget extends React.PureComponent<
       >
         {this.props.children}
       </Widget>
-    )
+    );
   }
 }

--- a/src/components/widget/DraggableWidget.tsx
+++ b/src/components/widget/DraggableWidget.tsx
@@ -7,17 +7,12 @@ import {IWidgetState, IWidgetProps, default as Widget} from './Widget';
 
 export interface IDraggableWidgetProps extends IWidgetProps {
   mover: RefObject<HTMLElement>;
-}
-
-export interface IDraggableWidgetState {
-  locationX: number;
-  locationY: number;
-  moved: boolean;
+  onDrag: (delta: IVec2) => void;
 }
 
 export default class DraggableWidget extends React.PureComponent<
     Partial<IDraggableWidgetProps>,
-    Partial<IDraggableWidgetState>
+  {}
   > {
 
   static defaultProps = {
@@ -40,10 +35,9 @@ export default class DraggableWidget extends React.PureComponent<
   }
 
   onDrag = (delta: IVec2) => {
-    this.setState({
-      locationX: this.state.locationX + delta.x,
-      locationY: this.state.locationY + delta.y,
-    });
+    if (this.props.onDrag) {
+      this.props.onDrag(delta);
+    }
     return true;
   }
 
@@ -68,18 +62,9 @@ export default class DraggableWidget extends React.PureComponent<
   }
 
   render() {
-    const {
-      locationX,
-      locationY,
-      moved,
-    } = this.state;
-
     return (
       <Widget
         {...this.props}
-        locationX={locationX}
-        locationY={locationY}
-        calculateInverted={!moved}
       >
         {this.props.children}
       </Widget>

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -3,24 +3,13 @@ import Menu from 'components/menu';
 import Viewer from 'components/viewer';
 import AnnotationViewModel from 'models/AnnotationViewModel';
 import Editor from 'components/editor';
+import Highlights from "../components/highlights/Highlights";
 
 export default function App() {
-
-  const annotation = new AnnotationViewModel({id: 1});
-    // mock data to display
-  annotation.comment = 'Testowy komentarz '.repeat(10);
-  annotation.referenceLinkTitle = 'Strona organizacji XYZ '.repeat(3);
-  annotation.doesBelongToUser = true;
-
   return (
     <div>
-      <Editor />
+      <Highlights />
       <Menu />
-      <Viewer
-        locationX={100}
-        locationY={700}
-        annotations={[annotation]}
-      />
     </div>
   );
 }

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -8,8 +8,10 @@ import Highlights from "../components/highlights/Highlights";
 export default function App() {
   return (
     <div>
+      <Editor />
       <Highlights />
       <Menu />
+      <Viewer />
     </div>
   );
 }

--- a/src/core/Highlighter.ts
+++ b/src/core/Highlighter.ts
@@ -102,7 +102,7 @@ export default class Highlighter {
   options;
   highlightRegistry: IHighlightRegistry;
 
-  constructor(element, options) {
+  constructor(element, options?) {
     this.element = element;
     this.options = {
       ...Highlighter.defaultOptions,
@@ -176,16 +176,21 @@ export default class Highlighter {
    */
   onHighlightEvent = (
     event: string,
-    handler: (e: any, annotationData: any) => void,
+    handler: (e: any, annotationData: any[]) => void,
   ) => {
     $(this.element)
       .on(event + '.' + this.options.nameSpace, '.' + this.options.highlightClass, (e) => {
-        const highlightElement = e.target;
-        if (highlightElement) {
-          const highlightId = $(highlightElement).attr(this.options.highlightIdAttr);
-          const data = this.highlightRegistry[highlightId.toString()];
-          handler(e, data.annotationData);
-        }
+
+        const annotations = $(e.target)
+                    .parents('.' + this.options.highlightClass)
+                    .addBack()
+                    .map((_, elem) => {
+                        return $(elem).attr(this.options.highlightIdAttr);
+                    })
+                    .toArray()
+                    .map(id => this.highlightRegistry[id.toString()].annotationData);
+
+        handler(e, annotations);
       });
   }
 

--- a/src/core/Highlighter.ts
+++ b/src/core/Highlighter.ts
@@ -189,7 +189,6 @@ export default class Highlighter {
                     })
                     .toArray()
                     .map(id => this.highlightRegistry[id.toString()].annotationData);
-
         handler(e, annotations);
       });
   }

--- a/src/core/TextSelector.ts
+++ b/src/core/TextSelector.ts
@@ -130,10 +130,6 @@ export default class TextSelector {
     // Get the currently selected ranges.
     const selectedRanges = this.captureDocumentSelection();
 
-    if (selectedRanges.length === 0) {
-      return;
-    }
-
     // Don't show the adder if the selection was of a part of Annotator itself.
     for (const selectedRange of selectedRanges) {
       let container = selectedRange.commonAncestor;

--- a/src/core/bootstrap.ts
+++ b/src/core/bootstrap.ts
@@ -25,7 +25,7 @@ export function deinitializeCoreHandlers() {
 function textSelectorCallback(selection: Range.SerializedRange[], event) {
   if (selection.length === 1) {
     store.dispatch(textSelectedAction(selection));
-    store.dispatch(showMenu(true, mousePosition(event)));
+    store.dispatch(showMenu(mousePosition(event)));
   } else {
     console.warn('PP: more than one selected range is not supported');
   }

--- a/src/core/bootstrap.ts
+++ b/src/core/bootstrap.ts
@@ -5,6 +5,7 @@ import store from 'store';
 import { showMenu, textSelectedAction } from 'store/actions';
 
 import { Highlighter, TextSelector } from './index';
+import {hideMenu} from 'store/widgets/actions';
 
 let handlers;
 
@@ -23,7 +24,9 @@ export function deinitializeCoreHandlers() {
 }
 
 function textSelectorCallback(selection: Range.SerializedRange[], event) {
-  if (selection.length === 1) {
+  if (selection.length === 0) {
+    store.dispatch(hideMenu());
+  } else if (selection.length === 1) {
     store.dispatch(textSelectedAction(selection));
     store.dispatch(showMenu(mousePosition(event)));
   } else {

--- a/src/core/bootstrap.ts
+++ b/src/core/bootstrap.ts
@@ -2,10 +2,11 @@ import { Range } from 'xpath-range';
 
 import { mousePosition } from 'common/dom';
 import store from 'store';
-import { showMenu, textSelectedAction } from 'store/actions';
+import { showMenu, makeSelection } from 'store/actions';
 
 import { Highlighter, TextSelector } from './index';
 import {hideMenu} from 'store/widgets/actions';
+import {noSelection} from 'store/textSelector/actions';
 
 let handlers;
 
@@ -26,8 +27,9 @@ export function deinitializeCoreHandlers() {
 function textSelectorCallback(selection: Range.SerializedRange[], event) {
   if (selection.length === 0) {
     store.dispatch(hideMenu());
+    store.dispatch(noSelection());
   } else if (selection.length === 1) {
-    store.dispatch(textSelectedAction(selection));
+    store.dispatch(makeSelection(selection[0]));
     store.dispatch(showMenu(mousePosition(event)));
   } else {
     console.warn('PP: more than one selected range is not supported');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,5 +35,4 @@ const isBrowser = typeof window !== 'undefined';
 if (isBrowser) {
   initializeCoreHandlers();
   injectApp();
-  store.dispatch(showEditorNewAnnotation(650, 500));
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import './css/common/pp-semantic-ui-reset.scss';
 import './css/common/pp-semantic-ui-overrides.scss';
 
 import './css/selection.scss';
-import {showEditorNewAnnotation} from "./store/widgets/actions";
+import {showEditorNewAnnotation} from 'store/widgets/actions';
 
 console.log('Przypis script working!');
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,2 +1,3 @@
 export * from './widgets/actions';
 export * from './textSelector/actions';
+export * from './annotations/actions';

--- a/src/store/annotations/actions.ts
+++ b/src/store/annotations/actions.ts
@@ -1,0 +1,8 @@
+export const CREATE_ANNOTATION = 'CREATE_ANNOTATION';
+
+export const createAnnotation = (annotation) => {
+  return {
+    type: CREATE_ANNOTATION,
+    payload: annotation,
+  };
+};

--- a/src/store/annotations/reducers.ts
+++ b/src/store/annotations/reducers.ts
@@ -1,6 +1,16 @@
+import {CREATE_ANNOTATION} from './actions';
 
-const initialState = [];
+const initialState = {
+  data: [],
+};
 
 export default function editor(state = initialState, action) {
-  return state;
+  switch (action.type) {
+    case CREATE_ANNOTATION:
+      return Object.assign({}, {
+        data: state.data.concat([action.payload]),
+      });
+    default:
+      return state;
+  }
 }

--- a/src/store/annotations/reducers.ts
+++ b/src/store/annotations/reducers.ts
@@ -4,11 +4,18 @@ const initialState = {
   data: [],
 };
 
+function maxId(state) {
+  return Math.max(0, ...state.data.map(annotation => annotation.annotationId)) + 1;
+}
+
 export default function editor(state = initialState, action) {
   switch (action.type) {
     case CREATE_ANNOTATION:
       return Object.assign({}, {
-        data: state.data.concat([action.payload]),
+        data: state.data.concat([{
+          ...action.payload,
+          annotationId: maxId(state),
+        }]),
       });
     default:
       return state;

--- a/src/store/annotations/reducers.ts
+++ b/src/store/annotations/reducers.ts
@@ -8,10 +8,11 @@ function maxId(state) {
   return Math.max(0, ...state.data.map(annotation => annotation.annotationId)) + 1;
 }
 
-export default function editor(state = initialState, action) {
+export default function annotations(state = initialState, action) {
   switch (action.type) {
     case CREATE_ANNOTATION:
       return Object.assign({}, {
+        ...state,
         data: state.data.concat([{
           ...action.payload,
           annotationId: maxId(state),

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -4,7 +4,7 @@ import textSelector from './textSelector/reducers';
 import annotations from './annotations/reducers';
 
 export interface IStore {
-  annotations: any[];
+  annotations: any;
   widgets: WidgetReducer;
   textSelector: any;
 }

--- a/src/store/textSelector/actions.ts
+++ b/src/store/textSelector/actions.ts
@@ -1,8 +1,21 @@
+import {Range} from 'xpath-range';
+
 export const TEXT_SELECTED = 'TEXT_SELECTED';
 
-export function textSelectedAction(payload) {
+export function makeSelection(range: Range.SerializedRange) {
   return {
     type: TEXT_SELECTED,
-    payload,
+    payload: {
+      range,
+    },
+  };
+}
+
+export function noSelection() {
+  return {
+    type: TEXT_SELECTED,
+    payload: {
+      range: null,
+    },
   };
 }

--- a/src/store/textSelector/reducers.ts
+++ b/src/store/textSelector/reducers.ts
@@ -1,22 +1,22 @@
 import { TEXT_SELECTED } from './actions';
 
-const initialState = {};
+const initialState = {
+  range: null,
+};
 
 export default function textSelector(state = initialState, action) {
   switch (action.type) {
     case TEXT_SELECTED:
-      console.log('Handle text selected action, data: ', action.data);
-      return textSelectedActionHandler(state, action.data);
+      console.log('Handle text selected action, data: ', action.payload);
+      return textSelectedActionHandler(state, action.payload);
     default:
       return state;
   }
 }
 
-function textSelectedActionHandler(state, data) {
-  // TODO
-  console.log('do sth with following data: ', data);
-
+function textSelectedActionHandler(state, payload) {
   return {
     ...state,
+    range: payload.range,
   };
 }

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -1,12 +1,15 @@
+import {Range} from 'xpath-range';
+
 export const EDITOR_VISIBLE_CHANGE = 'EDITOR_VISIBLE_CHANGE';
 export const MENU_WIDGET_CHANGE = 'MENU_WIDGET_CHANGE';
 export const EDITOR_NEW_ANNOTATION = 'EDITOR_NEW_ANNOTATION';
 
-export const showEditorNewAnnotation = (x: number, y: number) => {
+export const showEditorNewAnnotation = (x: number, y: number, range: Range.SerializedRange) => {
   return {
     type: EDITOR_NEW_ANNOTATION,
     payload: {
       annotationId: null,
+      range,
       visible: true,
       location: {
         x,

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -20,33 +20,11 @@ export const showEditorNewAnnotation = (x: number, y: number, range: Range.Seria
   };
 };
 
-export const showEditor = () => {
-  return {
-    type: EDITOR_VISIBLE_CHANGE,
-    payload: {
-      visible: true,
-    },
-  };
-};
-
 export const hideEditor = () => {
   return {
     type: EDITOR_VISIBLE_CHANGE,
     payload: {
       visible: false,
-    },
-  };
-};
-
-export const setEditor = (visible, x, y) => {
-  return {
-    type: EDITOR_VISIBLE_CHANGE,
-    payload: {
-      visible,
-      location: {
-        x,
-        y,
-      },
     },
   };
 };

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -16,19 +16,6 @@ export const showEditorNewAnnotation = (x: number, y: number) => {
   };
 };
 
-export const showMenu = (visible, { x, y }) => {
-  return {
-    type: MENU_WIDGET_CHANGE,
-    payload: {
-      visible: true,
-      location: {
-        x,
-        y,
-      },
-    },
-  };
-};
-
 export const showEditor = () => {
   return {
     type: EDITOR_VISIBLE_CHANGE,
@@ -56,6 +43,28 @@ export const setEditor = (visible, x, y) => {
         x,
         y,
       },
+    },
+  };
+};
+
+export const showMenu = ({ x, y }) => {
+  return {
+    type: MENU_WIDGET_CHANGE,
+    payload: {
+      visible: true,
+      location: {
+        x,
+        y,
+      },
+    },
+  };
+};
+
+export const hideMenu = () => {
+  return {
+    type: MENU_WIDGET_CHANGE,
+    payload: {
+      visible: false,
     },
   };
 };

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -1,8 +1,9 @@
 import {Range} from 'xpath-range';
 
-export const EDITOR_VISIBLE_CHANGE = 'EDITOR_VISIBLE_CHANGE';
-export const MENU_WIDGET_CHANGE = 'MENU_WIDGET_CHANGE';
 export const EDITOR_NEW_ANNOTATION = 'EDITOR_NEW_ANNOTATION';
+export const EDITOR_VISIBLE_CHANGE = 'EDITOR_VISIBLE_CHANGE';
+export const VIEWER_VISIBLE_CHANGE = 'VIEWER_VISIBLE_CHANGE';
+export const MENU_WIDGET_CHANGE = 'MENU_WIDGET_CHANGE';
 
 export const showEditorNewAnnotation = (x: number, y: number, range: Range.SerializedRange) => {
   return {
@@ -66,6 +67,29 @@ export const showMenu = ({ x, y }) => {
 export const hideMenu = () => {
   return {
     type: MENU_WIDGET_CHANGE,
+    payload: {
+      visible: false,
+    },
+  };
+};
+
+export const showViewer = (x: number, y: number, annotationIds: number[]) => {
+  return {
+    type: VIEWER_VISIBLE_CHANGE,
+    payload: {
+      annotationIds,
+      visible: true,
+      location: {
+        x,
+        y,
+      },
+    },
+  };
+};
+
+export const hideViewer = () => {
+  return {
+    type: VIEWER_VISIBLE_CHANGE,
     payload: {
       visible: false,
     },

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -6,6 +6,7 @@ export const showEditorNewAnnotation = (x: number, y: number) => {
   return {
     type: EDITOR_NEW_ANNOTATION,
     payload: {
+      annotationId: null,
       visible: true,
       location: {
         x,

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -2,6 +2,7 @@ import {
   EDITOR_NEW_ANNOTATION,
   EDITOR_VISIBLE_CHANGE,
   MENU_WIDGET_CHANGE,
+  VIEWER_VISIBLE_CHANGE,
 } from './actions';
 
 export interface IWidgetState {
@@ -9,9 +10,14 @@ export interface IWidgetState {
   location: {x: number; y: number};
 }
 
+export interface IViewerState extends IWidgetState {
+  annotationIds: any[];
+}
+
 export interface WidgetReducer {
   editor: IWidgetState;
   menu: IWidgetState;
+  viewer: IViewerState;
 }
 
 const initialWidgetState = {
@@ -30,6 +36,10 @@ const initialState = {
   menu: {
     ...initialWidgetState,
   },
+  viewer: {
+    ...initialWidgetState,
+    annotationIds: [],
+  },
 };
 
 export default function widgets(state = initialState, action): WidgetReducer {
@@ -39,6 +49,8 @@ export default function widgets(state = initialState, action): WidgetReducer {
       return editorActionHandler(state, action.payload);
     case MENU_WIDGET_CHANGE:
       return menuActionHandler(state, action.payload);
+    case VIEWER_VISIBLE_CHANGE:
+      return viewerActionHandler(state, action.payload);
     default:
       return state;
   }
@@ -59,6 +71,17 @@ function menuActionHandler(state, payload) {
     ...state,
     menu: {
       ...state.menu,
+      ...payload,
+    },
+  };
+}
+
+// todo here: update only when the annotations have changed
+function viewerActionHandler(state, payload) {
+  return {
+    ...state,
+    viewer: {
+      ...state.viewer,
       ...payload,
     },
   };

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -76,7 +76,8 @@ function menuActionHandler(state, payload) {
   };
 }
 
-// todo here: update only when the annotations have changed
+// todo here: update the location only when the annotations have also changed
+// (to prevent the window from changing the location once displayed for a
 function viewerActionHandler(state, payload) {
   return {
     ...state,

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -24,6 +24,7 @@ const initialWidgetState = {
 
 const initialState = {
   editor: {
+    annotationId: null,
     ...initialWidgetState,
   },
   menu: {

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -50,7 +50,7 @@ function editorActionHandler(state, payload) {
     editor: {
       ...state.editor,
       ...payload,
-    }
+    },
   };
 }
 

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -4,6 +4,7 @@ import {
   MENU_WIDGET_CHANGE,
   VIEWER_VISIBLE_CHANGE,
 } from './actions';
+import * as _ from "lodash";
 
 export interface IWidgetState {
   visible: boolean;
@@ -76,14 +77,24 @@ function menuActionHandler(state, payload) {
   };
 }
 
-// todo here: update the location only when the annotations have also changed
-// (to prevent the window from changing the location once displayed for a
 function viewerActionHandler(state, payload) {
+  // Update location only when the displayed annotations have changed, too.
+  // This prevents window from changing every time the user cursor slips off the widget
+  const prevIds = state.viewer.annotationIds;
+  const newIds = payload.annotationIds;
+  let locationOverride = {};
+  if (_.difference(prevIds, newIds).length === 0 && _.difference(newIds, prevIds).length === 0) {
+    locationOverride = {
+      location: state.viewer.location,
+    };
+  }
+
   return {
     ...state,
     viewer: {
       ...state.viewer,
       ...payload,
+      ...locationOverride,
     },
   };
 }

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import { IStore } from 'store/reducer';
 import {AnnotationPriorities} from '../../components/consts';
-import {IWidgetState, WidgetReducer} from "./reducers";
+import {IWidgetState, WidgetReducer} from './reducers';
 
 function selectWidgetState({ location, visible }) {
   return {
@@ -28,9 +28,9 @@ function selectAnnotationForm(annotations, annotationId?) {
   };
 }
 
-export const selectEditorState = createSelector<IStore, any, any[], any>(
+export const selectEditorState = createSelector<IStore, any, any, any>(
   state => state.widgets.editor,
-  state => state.annotations,
+  state => state.annotations.data,
   (editor, annotations) => ({
     ...selectWidgetState(editor),
     ...selectAnnotationForm(annotations, editor.annotationId),

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { IStore } from 'store/reducer';
-import {AnnotationPriorities} from '../../components/consts';
+import {AnnotationPriorities} from 'components/consts';
 import {IWidgetState, WidgetReducer} from './reducers';
 
 function selectWidgetState({ location, visible }) {
@@ -28,6 +28,10 @@ function selectAnnotationForm(annotations, annotationId?) {
   };
 }
 
+function selectViewerAnnotations(annotations: any[], annotationIds: any[]) {
+  return annotationIds.map(id => annotations.find(annotation => annotation.annotationId === id));
+}
+
 export const selectEditorState = createSelector<IStore, any, any, any>(
   state => state.widgets.editor,
   state => state.annotations.data,
@@ -41,4 +45,13 @@ export const selectEditorState = createSelector<IStore, any, any, any>(
 export const selectMenuState = createSelector<IStore, any, any>(
   state => state.widgets.menu,
   selectWidgetState,
+);
+
+export const selectViewerState = createSelector<IStore, any, any, any>(
+  state => state.widgets.viewer,
+  state => state.annotations.data,
+  (viewer, annotations) => ({
+    ...selectWidgetState(viewer),
+    annotations: selectViewerAnnotations(annotations, viewer.annotationIds),
+  }),
 );

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -34,6 +34,7 @@ export const selectEditorState = createSelector<IStore, any, any, any>(
   (editor, annotations) => ({
     ...selectWidgetState(editor),
     ...selectAnnotationForm(annotations, editor.annotationId),
+    range: editor.range,
   }),
 );
 

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -1,5 +1,7 @@
 import { createSelector } from 'reselect';
 import { IStore } from 'store/reducer';
+import {AnnotationPriorities} from '../../components/consts';
+import {IWidgetState, WidgetReducer} from "./reducers";
 
 function selectWidgetState({ location, visible }) {
   return {
@@ -9,12 +11,33 @@ function selectWidgetState({ location, visible }) {
   };
 }
 
-export const selectMenuState = createSelector<IStore, any, any>(
-  state => state.widgets.menu,
-  selectWidgetState,
+function selectAnnotationForm(annotations, annotationId?) {
+  let model;
+  if (annotationId) {
+    model = annotations.find(x => x.id === annotationId);
+  } else {
+    model = {};
+  }
+
+  return {
+    annotationId: model.id,
+    priority: model.priority || AnnotationPriorities.NORMAL,
+    comment: model.comment || '',
+    referenceLink: model.referenceLink || '',
+    referenceLinkTitle: model.referenceLinkTitle || '',
+  };
+}
+
+export const selectEditorState = createSelector<IStore, any, any[], any>(
+  state => state.widgets.editor,
+  state => state.annotations,
+  (editor, annotations) => ({
+    ...selectWidgetState(editor),
+    ...selectAnnotationForm(annotations, editor.annotationId),
+  }),
 );
 
-export const selectEditorState = createSelector<IStore, any, any>(
-  state => state.widgets.editor,
+export const selectMenuState = createSelector<IStore, any, any>(
+  state => state.widgets.menu,
   selectWidgetState,
 );

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -11,6 +11,11 @@ function selectWidgetState({ location, visible }) {
   };
 }
 
+export const selectMenuState = createSelector<IStore, any, any>(
+  state => state.widgets.menu,
+  selectWidgetState,
+);
+
 function selectAnnotationForm(annotations, annotationId?) {
   let model;
   if (annotationId) {
@@ -28,10 +33,6 @@ function selectAnnotationForm(annotations, annotationId?) {
   };
 }
 
-function selectViewerAnnotations(annotations: any[], annotationIds: any[]) {
-  return annotationIds.map(id => annotations.find(annotation => annotation.annotationId === id));
-}
-
 export const selectEditorState = createSelector<IStore, any, any, any>(
   state => state.widgets.editor,
   state => state.annotations.data,
@@ -42,10 +43,9 @@ export const selectEditorState = createSelector<IStore, any, any, any>(
   }),
 );
 
-export const selectMenuState = createSelector<IStore, any, any>(
-  state => state.widgets.menu,
-  selectWidgetState,
-);
+function selectViewerAnnotations(annotations: any[], annotationIds: any[]) {
+  return annotationIds.map(id => annotations.find(annotation => annotation.annotationId === id));
+}
 
 export const selectViewerState = createSelector<IStore, any, any, any>(
   state => state.widgets.viewer,

--- a/src/test.html
+++ b/src/test.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title><%= htmlWebpackPlugin.options.title %></title>
-    <link href="//fonts.googleapis.com/css?family=Open+Sans:300,600" rel="stylesheet">
+    <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,600" rel="stylesheet">
 </head>
 <body>
 <div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -161,4 +161,7 @@ const config = (env, argv) => ({
   ],
 });
 
-module.exports = config;
+module.exports = {
+  config: config,
+  BUILD_DIR: BUILD_DIR,
+};


### PR DESCRIPTION
**Fixes**:
- flattened `Editor` props and created editor selectors so it reacts only to actual prop changes
- finally limited `DraggableWidget` responsibilities to basic callback setup (before the modification every `Editor` input change reset its location to the one before dragging.
- fixed `Highlighter` to work with overlapping annotations
- restored prod build for GitHub CI

**New** (in Redux architecture)
- `Menu` disappears on deselection
- `Editor` pops up on `Menu` click
- `Viewer` appears on highlight mouseover
- temporary `state.annotations` further development to mock the backend before we connect to it
- `Highlights` component connected to the store that creates text highlights based on `state.annotations` (using `Highlighter` util)
- `Viewer`'s `connect` and selectors


**To Do**
- [ ] refactor after the changes
- [ ] `Viewer` disappearing on mouseleave

Fixes #33 