### PR TITLE
Editor and DraggableWidget local state management

### DIFF
--- a/src/api/annotations.ts
+++ b/src/api/annotations.ts
@@ -8,6 +8,7 @@ export interface RangeAPIModel {
 }
 
 export interface AnnotationAPICreateModel {
+  id?: string;
   type: string;
   attributes: {
     url: string;

--- a/src/api/annotations.ts
+++ b/src/api/annotations.ts
@@ -10,28 +10,32 @@ export interface RangeAPIModel {
 export interface AnnotationAPICreateModel {
   id?: string;
   type: string;
-  attributes: {
-    url: string;
-    range: RangeAPIModel;
-    priority: AnnotationPriorities;
-    comment: string;
-    annotationLink: string;
-    annotationLinkTitle: string;
-  };
+  attributes: AnnotationAPICreateModelAttrs;
+}
+
+export interface AnnotationAPICreateModelAttrs {
+  url: string;
+  range: RangeAPIModel;
+  priority: AnnotationPriorities;
+  comment: string;
+  annotationLink: string;
+  annotationLinkTitle: string;
 }
 
 export interface AnnotationAPIModel {
   id: string;
   type: string;
-  attributes: {
-    url: string;
-    range: RangeAPIModel;
-    priority: AnnotationPriorities;
-    comment: string;
-    annotationLink: string;
-    annotationLinkTitle: string;
-    upvote: boolean;
-    upvoteCount: number;
-    doesBelongToUser: boolean;
-  };
+  attributes: AnnotationAPIModelAttrs;
+}
+
+export interface AnnotationAPIModelAttrs {
+  url: string;
+  range: RangeAPIModel;
+  priority: AnnotationPriorities;
+  comment: string;
+  annotationLink: string;
+  annotationLinkTitle: string;
+  upvote: boolean;
+  upvoteCount: number;
+  doesBelongToUser: boolean;
 }

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -50,13 +50,8 @@ class Editor extends React.Component<
   Partial<IEditorProps>,
   Partial<IEditorState>
   > {
-   /*
-    * NOTE:
-    * For a comprehensive note on invertedX and invertedY see Widget component
-    */
 
   static defaultProps = {
-    visible: true,
     locationX: 0,
     locationY: 0,
   };
@@ -74,6 +69,8 @@ class Editor extends React.Component<
      * However, it is not enough, as two annotations can be made for the exact same range
      */
     const nextAnnotation: any = nextProps.annotation || {};
+    // Note: nextProps.annotation && nextProps.annotation.id === prevState.annotationId will generate updates
+    // if only nextProps.annotation is null
     const areAnnotationsEqual = prevState.annotationId === nextAnnotation.id;
     const areRangesEqual = _.isEqual(prevState.range, nextProps.range);
     if (areAnnotationsEqual && areRangesEqual) {
@@ -88,7 +85,6 @@ class Editor extends React.Component<
         annotationLink: attrs.annotationLink || '',
         annotationLinkTitle: attrs.annotationLinkTitle || '',
 
-        moved: false,
         locationX: nextProps.locationX,
         locationY: nextProps.locationY,
         annotationLinkError: '',
@@ -104,15 +100,6 @@ class Editor extends React.Component<
     super(props);
     this.state = {};
     this.moverElement = React.createRef();
-  }
-
-  onDrag = (delta: IVec2) => {
-    this.setState({
-      locationX: this.state.locationX + delta.x,
-      locationY: this.state.locationY + delta.y,
-      moved: true,
-    });
-    return true;
   }
 
   setPriority = (priority: AnnotationPriorities) => {
@@ -228,9 +215,6 @@ class Editor extends React.Component<
 
   render() {
     const {
-      locationX,
-      locationY,
-      moved,
       priority,
       comment,
       annotationLink,
@@ -242,12 +226,10 @@ class Editor extends React.Component<
     return (
       <DraggableWidget
         className={classNames('pp-ui', styles.self)}
-        locationX={locationX}
-        locationY={locationY}
-        calculateInverted={!moved}
+        initialLocationX={this.props.locationX}
+        initialLocationY={this.props.locationY}
         widgetTriangle={true}
         mover={this.moverElement}
-        onDrag={this.onDrag}
       >
         <div className={styles.headBar}>
           <label className={styles.priorityHeader}> Co dodajesz? </label>

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -20,7 +20,6 @@ import * as _ from 'lodash';
   (state) => {
 
     const {
-      visible,
       locationX,
       locationY,
 
@@ -29,7 +28,6 @@ import * as _ from 'lodash';
     } = selectEditorState(state);
 
     return {
-      visible,
       locationX,
       locationY,
 
@@ -241,14 +239,9 @@ class Editor extends React.Component<
       annotationLinkTitleError,
     } = this.state;
 
-    const {
-      visible,
-    } = this.props;
-
     return (
       <DraggableWidget
         className={classNames('pp-ui', styles.self)}
-        visible={visible}
         locationX={locationX}
         locationY={locationY}
         calculateInverted={!moved}

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1,6 +1,6 @@
 import React, {RefObject} from 'react';
 import {connect} from 'react-redux';
-import { createResource } from 'redux-json-api'
+import { createResource, updateResource } from 'redux-json-api';
 import classNames from 'classnames';
 import {Range} from 'xpath-range';
 import {Modal, Popup} from 'semantic-ui-react';
@@ -45,7 +45,13 @@ import {AnnotationAPICreateModel} from 'api/annotations';
   },
   dispatch => ({
     hideEditor: () => dispatch(hideEditor()),
-    createAnnotation: (data: AnnotationAPICreateModel) => dispatch(createResource(data)),
+    createAnnotation: (model: AnnotationAPICreateModel) => {
+      if (model.id) {
+        return dispatch(updateResource(model));
+      } else {
+        return dispatch(createResource(model));
+      }
+    }
   }),
 )
 class Editor extends React.Component<
@@ -168,7 +174,8 @@ class Editor extends React.Component<
   }
 
   save() {
-    const resourceData = {
+    const model = {
+      id: this.props.annotationId,
       type: 'annotations',
       attributes: {
         url: window.location.href,
@@ -179,7 +186,7 @@ class Editor extends React.Component<
         annotationLinkTitle: this.state.annotationLinkTitle,
       },
     };
-    this.props.createAnnotation(resourceData).then(() => {
+    this.props.createAnnotation(model).then(() => {
         this.props.hideEditor();
       })
       .catch((errors) => {

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -2,45 +2,39 @@ import React, {RefObject} from 'react';
 import {connect} from 'react-redux';
 import { createResource, updateResource } from 'redux-json-api';
 import classNames from 'classnames';
-import {Range} from 'xpath-range';
 import {Modal, Popup} from 'semantic-ui-react';
 import {AnnotationPriorities, annotationPrioritiesLabels} from '../consts';
 import {DragTracker, IVec2} from 'utils/move';
 import PriorityButton from './priority-button/PriorityButton';
-import {IEditorState, IEditorProps, IEditorForm} from './interfaces';
+import {IEditorState, IEditorProps } from './interfaces';
 import { DraggableWidget } from 'components/widget';
 import { hideEditor } from 'store/actions';
 import {selectEditorState} from 'store/selectors';
 
 import styles from './Editor.scss';
-import {AnnotationAPICreateModel} from 'api/annotations';
+import {AnnotationAPICreateModel, AnnotationAPIModel} from 'api/annotations';
+import {AnnotationAPIModelAttrs} from 'api/annotations';
+import * as _ from 'lodash';
 
 @connect(
   (state) => {
+
     const {
       visible,
       locationX,
       locationY,
+
       range,
-      // form
-      annotationId,
-      priority,
-      comment,
-      annotationLink,
-      annotationLinkTitle,
+      annotation,
     } = selectEditorState(state);
 
     return {
       visible,
       locationX,
       locationY,
+
       range,
-      // form
-      annotationId,
-      priority,
-      comment,
-      annotationLink,
-      annotationLinkTitle,
+      annotation,
     };
   },
   dispatch => ({
@@ -51,7 +45,7 @@ import {AnnotationAPICreateModel} from 'api/annotations';
       } else {
         return dispatch(createResource(model));
       }
-    }
+    },
   }),
 )
 class Editor extends React.Component<
@@ -75,21 +69,35 @@ class Editor extends React.Component<
     [AnnotationPriorities.ALERT]: styles.priorityAlert,
   };
 
-  static getDerivedStateFromProps(nextProps: IEditorProps) {
-    return {
-      annotationId: nextProps.annotationId,
-      priority: nextProps.priority,
-      comment: nextProps.comment,
-      annotationLink: nextProps.annotationLink,
-      annotationLinkTitle: nextProps.annotationLinkTitle,
+  static getDerivedStateFromProps(nextProps: IEditorProps, prevState: IEditorState) {
+    /*
+     * The window should update whenever either annotation or range changes
+     * Comparing ranges is crucial when the annotation was null before and is null again;
+     * However, it is not enough, as two annotations can be made for the exact same range
+     */
+    const nextAnnotation: any = nextProps.annotation || {};
+    const areAnnotationsEqual = prevState.annotationId === nextAnnotation.id;
+    const areRangesEqual = _.isEqual(prevState.range, nextProps.range);
+    if (areAnnotationsEqual && areRangesEqual) {
+      return { ...prevState };
+    } else {
+      const attrs: Partial<AnnotationAPIModelAttrs> = nextAnnotation.attributes || {};
+      return {
+        annotationId: nextAnnotation.id,
+        range: nextProps.range,
+        priority: attrs.priority ||  AnnotationPriorities.NORMAL,
+        comment: attrs.comment || '',
+        annotationLink: attrs.annotationLink || '',
+        annotationLinkTitle: attrs.annotationLinkTitle || '',
 
-      moved: false,
-      locationX: nextProps.locationX,
-      locationY: nextProps.locationY,
-      annotationLinkError: '',
-      annotationLinkTitleError: '',
-      noCommentModalOpen: false,
-    };
+        moved: false,
+        locationX: nextProps.locationX,
+        locationY: nextProps.locationY,
+        annotationLinkError: '',
+        annotationLinkTitleError: '',
+        noCommentModalOpen: false,
+      };
+    }
   }
 
   moverElement: RefObject<HTMLDivElement>;
@@ -98,10 +106,6 @@ class Editor extends React.Component<
     super(props);
     this.state = {};
     this.moverElement = React.createRef();
-  }
-
-  isNewAnnotation() {
-    return this.props.annotationId !== null;
   }
 
   onDrag = (delta: IVec2) => {
@@ -175,7 +179,7 @@ class Editor extends React.Component<
 
   save() {
     const model = {
-      id: this.props.annotationId,
+      id: this.props.annotation ? this.props.annotation.id : null,
       type: 'annotations',
       attributes: {
         url: window.location.href,

--- a/src/components/editor/interfaces.ts
+++ b/src/components/editor/interfaces.ts
@@ -1,26 +1,27 @@
 import {AnnotationPriorities} from '../consts';
-import {Range} from 'xpath-range';
-import {AnnotationAPICreateModel} from 'api/annotations';
+import {AnnotationAPICreateModel, AnnotationAPIModel} from 'api/annotations';
+import {IEditorRange} from 'store/widgets/reducers';
 
-export interface IEditorForm {
-  annotationId: number;
-  priority: AnnotationPriorities;
-  comment: string;
-  annotationLink: string;
-  annotationLinkTitle: string;
-}
-
-export interface IEditorProps extends IEditorForm {
+export interface IEditorProps {
   visible: boolean;
   locationX: number;
   locationY: number;
-  range: Range.SerializedRange;
+
+  annotation: AnnotationAPIModel;
+  range: IEditorRange;
 
   createAnnotation: (model: AnnotationAPICreateModel) => Promise<object>;
   hideEditor: () => void;
 }
 
-export interface IEditorState extends IEditorForm {
+export interface IEditorState {
+  annotationId: string;
+  priority: AnnotationPriorities;
+  comment: string;
+  annotationLink: string;
+  annotationLinkTitle: string;
+  range: IEditorRange;
+
   locationX: number;
   locationY: number;
   moved: boolean;

--- a/src/components/editor/interfaces.ts
+++ b/src/components/editor/interfaces.ts
@@ -16,7 +16,7 @@ export interface IEditorProps extends IEditorForm {
   locationY: number;
   range: Range.SerializedRange;
 
-  createAnnotation: (resourceData: AnnotationAPICreateModel) => Promise<object>;
+  createAnnotation: (model: AnnotationAPICreateModel) => Promise<object>;
   hideEditor: () => void;
 }
 

--- a/src/components/editor/interfaces.ts
+++ b/src/components/editor/interfaces.ts
@@ -3,7 +3,6 @@ import {AnnotationAPICreateModel, AnnotationAPIModel} from 'api/annotations';
 import {IEditorRange} from 'store/widgets/reducers';
 
 export interface IEditorProps {
-  visible: boolean;
   locationX: number;
   locationY: number;
 

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -11,7 +11,6 @@ import {hideMenu, setSelectionRange, showEditorAnnotation} from 'store/widgets/a
 import {Range} from 'xpath-range';
 
 interface IMenuProps {
-  visible: boolean;
   locationX: number;
   locationY: number;
   range: Range.SerializedRange;
@@ -24,13 +23,11 @@ interface IMenuProps {
 @connect(
   (state) => {
   const {
-    visible,
     locationX,
     locationY,
   } = selectMenuState(state);
 
   return {
-    visible,
     locationX,
     locationY,
     range: state.textSelector.range,
@@ -70,7 +67,6 @@ export default class Menu extends React.Component<Partial<IMenuProps>, {}> {
     return (
       <Widget
         className={classNames('pp-ui', styles.self)}
-        visible={this.props.visible}
         locationX={this.props.locationX}
         locationY={this.props.locationY}
       >

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -7,7 +7,7 @@ import { selectMenuState } from 'store/selectors';
 import Widget from 'components/widget';
 
 import styles from './Menu.scss';
-import {hideMenu, showEditorNewAnnotation} from 'store/widgets/actions';
+import {hideMenu, setSelectionRange, showEditorAnnotation} from 'store/widgets/actions';
 import {Range} from 'xpath-range';
 
 interface IMenuProps {
@@ -16,7 +16,8 @@ interface IMenuProps {
   locationY: number;
   range: Range.SerializedRange;
 
-  showEditor: (x: number, y: number, range: Range.SerializedRange) => void;
+  setSelectionRange: (range: Range.SerializedRange) => void;
+  showEditor: (x: number, y: number) => void;
   hideMenu: () => void;
 }
 
@@ -36,7 +37,8 @@ interface IMenuProps {
   };
 },
   {
-    showEditor: showEditorNewAnnotation,
+    showEditor: showEditorAnnotation,
+    setSelectionRange,
     hideMenu,
   },
 )
@@ -60,7 +62,8 @@ export default class Menu extends React.Component<Partial<IMenuProps>, {}> {
     } = this.props;
 
     this.props.hideMenu();
-    this.props.showEditor(locationX, locationY, range);
+    this.props.setSelectionRange(range);
+    this.props.showEditor(locationX, locationY);
   }
 
   render() {

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -6,7 +6,7 @@ import Widget from 'components/widget';
 import ViewerItem from './ViewerItem';
 import styles from './Viewer.scss';
 import {selectViewerState} from 'store/widgets/selectors';
-import {hideViewer} from 'store/widgets/actions';
+import {hideViewer, showEditorAnnotation} from 'store/widgets/actions';
 import {AnnotationPriorities} from '../consts';
 import {AnnotationAPIModel} from 'api/annotations';
 
@@ -15,6 +15,8 @@ interface IViewerProps {
   locationX: number;
   locationY: number;
   annotations: AnnotationAPIModel[];
+
+  showEditorAnnotation: (x: number, y: number, id?: string) => void;
   hideViewer: () => void;
 }
 
@@ -39,9 +41,10 @@ interface IViewerProps {
       annotations,
     };
   },
-  dispatch => ({
-    hideViewer: () => dispatch(hideViewer()),
-  }),
+  {
+    showEditorAnnotation,
+    hideViewer,
+  },
 )
 export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
 
@@ -56,6 +59,23 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
     super(props);
   }
 
+  onItemEdit = (id: string) => {
+    const {
+      locationX,
+      locationY,
+    } = this.props;
+
+    this.props.showEditorAnnotation(locationX, locationY, id);
+    this.props.hideViewer();
+  }
+
+  onItemDelete = (id: string) => {
+    // [roadmap 5.3] TODO connect to redux-json-api call
+    console.log('Annotations should be deleted now; not implemented yet!');
+    this.props.hideViewer();
+  }
+
+
   renderItems() {
     return this.props.annotations.map((annotation) => {
       const attrs = annotation.attributes;
@@ -63,6 +83,7 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
         <ViewerItem
           key={annotation.id}
 
+          annotationId={annotation.id}
           comment={attrs.comment}
           doesBelongToUser={attrs.doesBelongToUser}
           priority={attrs.priority}
@@ -70,6 +91,8 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
           upvoteCount={attrs.upvoteCount}
           annotationLink={attrs.annotationLink}
           annotationLinkTitle={attrs.annotationLinkTitle}
+          onEdit={this.onItemEdit}
+          onDelete={this.onItemDelete}
 
           createDate={new Date()} // TODO use date from API (now missing)
         />

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -7,7 +7,7 @@ import ViewerItem from './ViewerItem';
 import styles from './Viewer.scss';
 import {selectViewerState} from 'store/widgets/selectors';
 import {hideViewer, showEditorAnnotation} from 'store/widgets/actions';
-import {AnnotationPriorities} from '../consts';
+import {AnnotationPriorities} from 'components/consts';
 import {AnnotationAPIModel} from 'api/annotations';
 
 interface IViewerProps {
@@ -68,10 +68,9 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
 
   onItemDelete = (id: string) => {
     // [roadmap 5.3] TODO connect to redux-json-api call
-    console.log('Annotations should be deleted now; not implemented yet!');
+    console.log('Annotation should be deleted now; not implemented yet!');
     this.props.hideViewer();
   }
-
 
   renderItems() {
     return this.props.annotations.map((annotation) => {
@@ -103,7 +102,7 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
         className={classNames('pp-ui', styles.self)}
         locationX={this.props.locationX}
         locationY={this.props.locationY}
-        calculateInverted={true}
+        updateInverted={true}
         widgetTriangle={true}
         onMouseLeave={this.props.hideViewer}
       >

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -11,7 +11,6 @@ import {AnnotationPriorities} from '../consts';
 import {AnnotationAPIModel} from 'api/annotations';
 
 interface IViewerProps {
-  visible: boolean;
   locationX: number;
   locationY: number;
   annotations: AnnotationAPIModel[];
@@ -28,14 +27,12 @@ interface IViewerProps {
 @connect(
   (state) => {
     const {
-      visible,
       locationX,
       locationY,
       annotations,
     } = selectViewerState(state);
 
     return {
-      visible,
       locationX,
       locationY,
       annotations,
@@ -104,7 +101,6 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
     return (
       <Widget
         className={classNames('pp-ui', styles.self)}
-        visible={this.props.visible}
         locationX={this.props.locationX}
         locationY={this.props.locationY}
         calculateInverted={true}

--- a/src/components/viewer/ViewerItem.tsx
+++ b/src/components/viewer/ViewerItem.tsx
@@ -4,15 +4,16 @@ import { connect } from 'react-redux';
 import moment from 'moment';
 import { Popup, Modal, Button } from 'semantic-ui-react';
 
-
 import { AnnotationPriorities, annotationPrioritiesLabels } from '../consts';
 import styles from './Viewer.scss';
-import {hideViewer} from 'store/widgets/actions';
+import {hideViewer, setSelectionRange, showEditorAnnotation} from 'store/widgets/actions';
 import {selectViewerState} from 'store/widgets/selectors';
+import {Range} from 'xpath-range';
 
 interface IViewerItemProps {
   key: string;
 
+  annotationId: string;
   doesBelongToUser: boolean;
   priority: AnnotationPriorities;
   upvote: boolean;
@@ -22,7 +23,8 @@ interface IViewerItemProps {
   annotationLinkTitle: string;
   createDate: any;
 
-  hideViewer: () => void;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
 }
 
 interface IViewerItemState {
@@ -32,6 +34,7 @@ interface IViewerItemState {
 
 @connect(
   null, {
+    showEditorAnnotation,
     hideViewer,
   },
 )
@@ -60,22 +63,17 @@ export default class ViewerItem extends React.Component<Partial<IViewerItemProps
       ViewerItem.editControlDisappearTimeout,
     );
   }
+  onEditClick = (e) => {
+    this.props.onEdit(this.props.annotationId);
+  }
 
-  handleEdit = (e) => {
-    this.props.hideViewer();
-    // [roadmap 6.4.1.3] TODO on "edit" open the Editor for edit.
-    console.log('Editor should open now with the form filled in; not implemented yet!');
+  onDeleteClick = (e) => {
+    this.props.onDelete(this.props.annotationId);
   }
 
   setDeleteModalOpen = e => this.setState({ confirmDeleteModalOpen: true });
 
   setDeleteModalClosed = e => this.setState({ confirmDeleteModalOpen: false });
-
-  handleDelete = (e) => {
-    this.props.hideViewer();
-    // [roadmap 5.3] TODO connect handleDelete to redux-json-api call
-    console.log('Annotations should be deleted now; not implemented yet!');
-  }
 
   toggleUpvote = (e) => {
     // [roadmap 5.3] TODO connect toggleUpvote to redux-json-api call
@@ -116,7 +114,7 @@ export default class ViewerItem extends React.Component<Partial<IViewerItemProps
           <Button onClick={this.setDeleteModalClosed} size="tiny" negative={true}>
             Nie
           </Button>
-          <Button onClick={this.handleDelete} size="tiny" positive={true}>
+          <Button onClick={this.onDeleteClick} size="tiny" positive={true}>
             Tak
           </Button>
         </Modal.Actions>
@@ -132,7 +130,7 @@ export default class ViewerItem extends React.Component<Partial<IViewerItemProps
           <button
             type="button"
             title="Edit"
-            onClick={this.handleEdit}
+            onClick={this.onEditClick}
           >
             <i className="edit icon" />
           </button>

--- a/src/components/widget/DraggableWidget.tsx
+++ b/src/components/widget/DraggableWidget.tsx
@@ -4,40 +4,71 @@ import styles from './Widget.scss';
 import {isInverted} from './utils';
 import {DragTracker, IVec2} from 'utils/move';
 import {IWidgetState, IWidgetProps, default as Widget} from './Widget';
+import {AnnotationAPIModelAttrs} from 'api/annotations';
+import {AnnotationPriorities} from '../consts';
+import * as _ from 'lodash';
+import {IEditorProps, IEditorState} from 'components/editor/interfaces';
 
-export interface IDraggableWidgetProps extends IWidgetProps {
+export interface IDraggableWidgetProps {
+  // Props consumed by DraggableWidget
   mover: RefObject<HTMLElement>;
-  onDrag: (delta: IVec2) => void;
+  initialLocationX: number;
+  initialLocationY: number;
+
+  // Props passed to Widget
+  children: any;
+  widgetTriangle: boolean;
+  className: string;
+}
+
+export interface IDraggableWidgetState {
+  initialLocationX: number;
+  initialLocationY: number;
+  locationX: number;
+  locationY: number;
+  hasBeenDragged: boolean;
 }
 
 export default class DraggableWidget extends React.PureComponent<
     Partial<IDraggableWidgetProps>,
-  {}
+    Partial<IDraggableWidgetState>
   > {
 
   static defaultProps = {
-    ...Widget.defaultProps,
+    initialLocationX: 0,
+    initialLocationY: 0,
   };
 
-  static getDerivedStateFromProps(nextProps) {
-    return {
-      locationX: nextProps.locationX,
-      locationY: nextProps.locationY,
-      moved: false,
-    };
+  static getDerivedStateFromProps(nextProps: IDraggableWidgetProps, prevState: IDraggableWidgetState) {
+    const areInitialLocationsEqual =
+      prevState.initialLocationX === nextProps.initialLocationX
+      && prevState.initialLocationY === nextProps.initialLocationY;
+    if (areInitialLocationsEqual) {
+      return {...prevState};
+    } else {
+      return {
+        initialLocationX: nextProps.initialLocationX,
+        initialLocationY: nextProps.initialLocationY,
+        locationX: nextProps.initialLocationX,
+        locationY: nextProps.initialLocationY,
+        hasBeenDragged: false,
+      };
+    }
   }
 
   dragTracker: DragTracker;
 
-  constructor(props: IWidgetProps) {
+  constructor(props: IDraggableWidgetProps) {
     super(props);
     this.state = {};
   }
 
   onDrag = (delta: IVec2) => {
-    if (this.props.onDrag) {
-      this.props.onDrag(delta);
-    }
+    this.setState({
+      locationX: this.state.locationX + delta.x,
+      locationY: this.state.locationY + delta.y,
+      hasBeenDragged: true,
+    });
     return true;
   }
 
@@ -56,16 +87,29 @@ export default class DraggableWidget extends React.PureComponent<
     this.setupDragTracker();
   }
 
-  componentDidUpdate() {
-    // called on all but the first render
-    this.setupDragTracker();
-  }
-
   render() {
+    const {
+      widgetTriangle,
+      className,
+    } = this.props;
+
+    const {
+      locationX,
+      locationY,
+      hasBeenDragged,
+    } = this.state;
+
     return (
       <Widget
-        {...this.props}
-      />
+        locationX={locationX}
+        locationY={locationY}
+        updateInverted={!hasBeenDragged}
+
+        widgetTriangle={widgetTriangle}
+        className={className}
+      >
+        {this.props.children}
+      </Widget>
     );
   }
 }

--- a/src/components/widget/Widget.scss
+++ b/src/components/widget/Widget.scss
@@ -64,7 +64,7 @@ When window is horizontally or vertically inverted
     top: -9px;
 }
 
-.inner.calculate-inverted {
+.inner.update-inverted {
     visibility: hidden;
 }
 //TODO

--- a/src/components/widget/Widget.tsx
+++ b/src/components/widget/Widget.tsx
@@ -9,11 +9,11 @@ export interface IWidgetProps {
   invertedX: boolean;
   invertedY: boolean;
   /*
-   * calculateInverted - (overwrites invertedX and invertedY)
+   * updateInverted - (overwrites invertedX and invertedY)
    * if true, the widget horizontal or vertical inversion will be calculated based on the window location
    * after the component is rendered for the first time after prop change
    */
-  calculateInverted: boolean;
+  updateInverted: boolean;
   widgetTriangle: boolean;
 
   className: string;
@@ -24,12 +24,12 @@ export interface IWidgetProps {
 export interface IWidgetState {
   invertedX: boolean;
   invertedY: boolean;
-  calculateInverted: boolean;
+  updateInverted: boolean;
 }
 
 export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
   Partial<IWidgetState>> {
-  /* Every time the component receives new props and  `calculateInverted` is true, `invertedX` and `invertedY`
+  /* Every time the component receives new props and  `updateInverted` is true, `invertedX` and `invertedY`
    * will be calculated based on the `locationX` and `locationY` props so the component is fully visible in the window
    *
    * NOTE:
@@ -51,7 +51,7 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
     locationY: 0,
     invertedX: false,
     invertedY: false,
-    calculateInverted: false,
+    updateInverted: false,
     className: '',
     onMouseLeave: null,
     widgetTriangle: false,
@@ -59,11 +59,11 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
 
   static getDerivedStateFromProps(nextProps: IWidgetProps) {
     /*
-     * If calculateInverted prop is set to true, invertedX and invertedY are set to false, so the initial measurements
+     * If updateInverted prop is set to true, invertedX and invertedY are set to false, so the initial measurements
      * may take place after the first render
     */
     let inverted;
-    if (nextProps.calculateInverted) {
+    if (nextProps.updateInverted) {
       inverted = {
         invertedX: false,
         invertedY: false,
@@ -71,7 +71,7 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
     }
     return {
       ...inverted,
-      calculateInverted: nextProps.calculateInverted,
+      updateInverted: nextProps.updateInverted,
     };
   }
 
@@ -93,7 +93,7 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
         [styles.widgetTriangle]: this.props.widgetTriangle,
         [styles.invertX]: this.state.invertedX,
         [styles.invertY]: this.state.invertedY,
-        [styles.calculateInverted]: this.state.calculateInverted,
+        [styles.updateInverted]: this.state.updateInverted,
       },
     );
   }
@@ -106,7 +106,7 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
     }
   }
 
-  mountedOrUpdated() {
+  onMountedOrUpdated() {
     // Set the CSS left/top properties
     this.setLocationStyle();
 
@@ -116,20 +116,20 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
       inner.addEventListener('mouseleave', this.props.onMouseLeave);
     }
 
-    if (this.state.calculateInverted) {
+    if (this.state.updateInverted) {
       this.setState({
         ...isInverted(this.innerElement.current, window),
-        calculateInverted: false,
+        updateInverted: false,
       });
     }
   }
 
   componentDidMount() {
-    this.mountedOrUpdated();
+    this.onMountedOrUpdated();
   }
 
   componentDidUpdate(prevProps, prevState) {
-    this.mountedOrUpdated();
+    this.onMountedOrUpdated();
   }
 
   render() {

--- a/src/components/widget/Widget.tsx
+++ b/src/components/widget/Widget.tsx
@@ -4,7 +4,6 @@ import styles from './Widget.scss';
 import {isInverted} from './utils';
 
 export interface IWidgetProps {
-  visible: boolean;
   locationX: number;
   locationY: number;
   invertedX: boolean;
@@ -48,7 +47,6 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
    */
 
   static defaultProps = {
-    visible: true,
     locationX: 0,
     locationY: 0,
     invertedX: false,
@@ -135,22 +133,18 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
   }
 
   render() {
-    if (this.props.visible) {
-      return (
+    return (
+      <div
+        className={styles.self}
+        ref={this.rootElement}
+      >
         <div
-          className={styles.self}
-          ref={this.rootElement}
+          className={this.getInnerClassNames()}
+          ref={this.innerElement}
         >
-          <div
-            className={this.getInnerClassNames()}
-            ref={this.innerElement}
-          >
-            {this.props.children}
-          </div>
+          {this.props.children}
         </div>
-      );
-    } else {
-      return null;
-    }
+      </div>
+    );
   }
 }

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -6,24 +6,25 @@ import Highlights from 'components/highlights/Highlights';
 import {connect} from 'react-redux';
 
 interface AppProps {
-  editorVisible: boolean;
+  editor: any;
   viewerVisible: boolean;
   menuVisible: boolean;
 }
 
 @connect(
   state => ({
-    editorVisible: state.widgets.editor.visible,
+    editor: state.widgets.editor,
     viewerVisible: state.widgets.viewer.visible,
     menuVisible: state.widgets.menu.visible,
   }),
 )
 export default class App extends React.Component<Partial<AppProps>> {
-
+  // always updates...:
+  // <Editor key={JSON.stringify(this.props.editor.range) + JSON.stringify(this.props.editor.annotationId)}/>
   render() {
     return (
       <div>
-        {this.props.editorVisible && <Editor/>}
+        {this.props.editor.visible && <Editor/>}
         {this.props.viewerVisible && <Viewer/>}
         {this.props.menuVisible && <Menu/>}
         <Highlights/>

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -3,14 +3,31 @@ import Menu from 'components/menu';
 import Viewer from 'components/viewer';
 import Editor from 'components/editor';
 import Highlights from 'components/highlights/Highlights';
+import {connect} from 'react-redux';
 
-export default function App() {
-  return (
-    <div>
-      <Editor />
-      <Highlights />
-      <Menu />
-      <Viewer />
-    </div>
-  );
+interface AppProps {
+  editorVisible: boolean;
+  viewerVisible: boolean;
+  menuVisible: boolean;
+}
+
+@connect(
+  state => ({
+    editorVisible: state.widgets.editor.visible,
+    viewerVisible: state.widgets.viewer.visible,
+    menuVisible: state.widgets.menu.visible,
+  }),
+)
+export default class App extends React.Component<Partial<AppProps>> {
+
+  render() {
+    return (
+      <div>
+        {this.props.editorVisible && <Editor/>}
+        {this.props.viewerVisible && <Viewer/>}
+        {this.props.menuVisible && <Menu/>}
+        <Highlights/>
+      </div>
+    );
+  }
 }

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -1,16 +1,16 @@
 import {Range} from 'xpath-range';
 
-export const EDITOR_NEW_ANNOTATION = 'EDITOR_NEW_ANNOTATION';
+export const EDITOR_ANNOTATION = 'EDITOR_ANNOTATION';
+export const SET_EDITOR_SELECTION_RANGE = 'SET_EDITOR_SELECTION_RANGE';
 export const EDITOR_VISIBLE_CHANGE = 'EDITOR_VISIBLE_CHANGE';
 export const VIEWER_VISIBLE_CHANGE = 'VIEWER_VISIBLE_CHANGE';
 export const MENU_WIDGET_CHANGE = 'MENU_WIDGET_CHANGE';
 
-export const showEditorNewAnnotation = (x: number, y: number, range: Range.SerializedRange) => {
+export const showEditorAnnotation = (x: number, y: number, id?: string) => {
   return {
-    type: EDITOR_NEW_ANNOTATION,
+    type: EDITOR_ANNOTATION,
     payload: {
-      annotationId: null,
-      range,
+      annotationId: id,
       visible: true,
       location: {
         x,
@@ -20,7 +20,14 @@ export const showEditorNewAnnotation = (x: number, y: number, range: Range.Seria
   };
 };
 
-// TODO sth like showEditorAnnotation for existing annotation edit
+export const setSelectionRange = (range: Range.SerializedRange) => {
+  return {
+    type: SET_EDITOR_SELECTION_RANGE,
+    payload: {
+      range,
+    },
+  };
+};
 
 export const hideEditor = () => {
   return {

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -20,11 +20,17 @@ export const showEditorAnnotation = (x: number, y: number, id?: string) => {
   };
 };
 
+// Note: range is explicitly rewritten, so it becomes a pure object (no functions)
 export const setSelectionRange = (range: Range.SerializedRange) => {
   return {
     type: SET_EDITOR_SELECTION_RANGE,
     payload: {
-      range,
+      range: {
+        start: range.start,
+        startOffset: range.startOffset,
+        end: range.end,
+        endOffset: range.endOffset,
+      }
     },
   };
 };

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -1,10 +1,11 @@
 import {
-  EDITOR_NEW_ANNOTATION,
+  EDITOR_ANNOTATION,
   EDITOR_VISIBLE_CHANGE,
-  MENU_WIDGET_CHANGE,
+  MENU_WIDGET_CHANGE, SET_EDITOR_SELECTION_RANGE,
   VIEWER_VISIBLE_CHANGE,
 } from './actions';
-import * as _ from "lodash";
+import * as _ from 'lodash';
+import {Range} from 'xpath-range';
 
 export interface IWidgetState {
   visible: boolean;
@@ -12,11 +13,16 @@ export interface IWidgetState {
 }
 
 export interface IViewerState extends IWidgetState {
-  annotationIds: any[];
+  annotationIds: string[];
+}
+
+export interface IEditorState extends IWidgetState {
+  annotationId: string;
+  range: Range.SerializedRange;
 }
 
 export interface WidgetReducer {
-  editor: IWidgetState;
+  editor: IEditorState;
   menu: IWidgetState;
   viewer: IViewerState;
 }
@@ -32,6 +38,7 @@ const initialWidgetState = {
 const initialState = {
   editor: {
     annotationId: null,
+    range: null,
     ...initialWidgetState,
   },
   menu: {
@@ -46,7 +53,8 @@ const initialState = {
 export default function widgets(state = initialState, action): WidgetReducer {
   switch (action.type) {
     case EDITOR_VISIBLE_CHANGE:
-    case EDITOR_NEW_ANNOTATION:
+    case EDITOR_ANNOTATION:
+    case SET_EDITOR_SELECTION_RANGE:
       return editorActionHandler(state, action.payload);
     case MENU_WIDGET_CHANGE:
       return menuActionHandler(state, action.payload);
@@ -79,7 +87,7 @@ function menuActionHandler(state, payload) {
 
 function viewerActionHandler(state, payload) {
   // Update location only when the displayed annotations have changed, too.
-  // This prevents window from changing every time the user cursor slips off the widget
+  // This prevents window from changing every time the user's cursor slips off the widget
   const prevIds = state.viewer.annotationIds;
   const newIds = payload.annotationIds;
   let locationOverride = {};

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -5,7 +5,6 @@ import {
   VIEWER_VISIBLE_CHANGE,
 } from './actions';
 import * as _ from 'lodash';
-import {Range} from 'xpath-range';
 
 export interface IWidgetState {
   visible: boolean;
@@ -16,9 +15,17 @@ export interface IViewerState extends IWidgetState {
   annotationIds: string[];
 }
 
+// IEditorRange differs from Range.SerializedRange in that it is a simple object (not a class)
+export interface IEditorRange {
+  start: string;
+  startOffset: number;
+  end: string;
+  endOffset: number;
+}
+
 export interface IEditorState extends IWidgetState {
   annotationId: string;
-  range: Range.SerializedRange;
+  range: IEditorRange;
 }
 
 export interface WidgetReducer {

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import { IStore } from 'store/reducer';
 import {AnnotationPriorities} from 'components/consts';
 import {IWidgetState, WidgetReducer} from './reducers';
+import {AnnotationAPIModel} from 'api/annotations';
 
 function selectWidgetState({ location, visible }) {
   return {
@@ -18,25 +19,20 @@ export const selectMenuState = createSelector<IStore, any, any>(
 
 function selectAnnotationForm(annotations, editor) {
   const annotationId = editor.annotationId;
-  let attrs;
   // When the annotation is being created for the first time, range is stored in state.editor.range;
   // If the annotation already exists, it is taken from annotation API model.
   let range;
+  let annotation;
   if (annotationId) {
-    const model = annotations.find(x => x.id === annotationId);
-    attrs = model.attributes;
-    range = attrs.range;
+    annotation = annotations.find(x => x.id === annotationId);
+    range = annotation.attributes.range;
   } else {
-    attrs = {};
+    annotation = null;
     range = editor.range;
   }
 
   return {
-    annotationId,
-    priority: attrs.priority || AnnotationPriorities.NORMAL,
-    comment: attrs.comment || '',
-    annotationLink: attrs.annotationLink || '',
-    annotationLinkTitle: attrs.annotationLinkTitle || '',
+    annotation,
     range,
   };
 }

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -17,19 +17,20 @@ export const selectMenuState = createSelector<IStore, any, any>(
 );
 
 function selectAnnotationForm(annotations, annotationId?) {
-  let model;
+  let attrs;
   if (annotationId) {
-    model = annotations.find(x => x.id === annotationId);
+    const model = annotations.find(x => x.id === annotationId);
+    attrs = model.attributes;
   } else {
-    model = {};
+    attrs = {};
   }
 
   return {
-    annotationId: model.id,
-    priority: model.priority || AnnotationPriorities.NORMAL,
-    comment: model.comment || '',
-    annotationLink: model.annotationLink || '',
-    annotationLinkTitle: model.annotationLinkTitle || '',
+    annotationId,
+    priority: attrs.priority || AnnotationPriorities.NORMAL,
+    comment: attrs.comment || '',
+    annotationLink: attrs.annotationLink || '',
+    annotationLinkTitle: attrs.annotationLinkTitle || '',
   };
 }
 

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -16,13 +16,19 @@ export const selectMenuState = createSelector<IStore, any, any>(
   selectWidgetState,
 );
 
-function selectAnnotationForm(annotations, annotationId?) {
+function selectAnnotationForm(annotations, editor) {
+  const annotationId = editor.annotationId;
   let attrs;
+  // When the annotation is being created for the first time, range is stored in state.editor.range;
+  // If the annotation already exists, it is taken from annotation API model.
+  let range;
   if (annotationId) {
     const model = annotations.find(x => x.id === annotationId);
     attrs = model.attributes;
+    range = attrs.range;
   } else {
     attrs = {};
+    range = editor.range;
   }
 
   return {
@@ -31,6 +37,7 @@ function selectAnnotationForm(annotations, annotationId?) {
     comment: attrs.comment || '',
     annotationLink: attrs.annotationLink || '',
     annotationLinkTitle: attrs.annotationLinkTitle || '',
+    range,
   };
 }
 
@@ -39,8 +46,7 @@ export const selectEditorState = createSelector<IStore, any, any, any>(
   state => state.api.annotations ? state.api.annotations.data : [],
   (editor, annotations) => ({
     ...selectWidgetState(editor),
-    ...selectAnnotationForm(annotations, editor.annotationId),
-    range: editor.range,
+    ...selectAnnotationForm(annotations, editor),
   }),
 );
 


### PR DESCRIPTION
**To be merged only after #54** 

**Summary**
- meeting the goal that it should be possible to open Editor for a new annotation while one is already open. (Solution discussed in https://slack-redir.net/link?url=https%3A%2F%2Fgithub.com%2FPrzypisPowszechny%2Fpp-client%2Fpull%2F50 (outdated, beginning with "Couldn't ...") assumes Editor's opening is always preceded by setting `editor.visible` to `false`). For this reason:
    - `Editor` & `DraggableWidget` local state is managed not with constructor but with a condition in `getDerivedStateFromProps`.
    - Location is not managed by `Editor` any more, but by `DraggableWidget` now.
- component conditional rendering to App; not necessary, but as it happens, `visible` is not passed down through 3 components' props any more. (we can easily drop this change).
