### PR TITLE
Further UI fixes

### DIFF
--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -98,12 +98,11 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, Parti
   onMouseLeave = (e) => {
     // Normally, close the window, except...
     // not when the modal is not open
-    if (!this.state.confirmDeleteModalOpen) {
+    // not when this element is manually marked as an indirect Viewer child (despite not being a DOM child)
+    const isMouseOverIndirectChild = e.relatedTarget.classList.contains(PPViewerIndirectChildClass);
+    if (!this.state.confirmDeleteModalOpen && !isMouseOverIndirectChild) {
       // check what element the pointer entered;
-      // not when this element is manually marked as an indirect Viewer child (despite not being a DOM child)
-      if (!e.relatedTarget.classList.contains(PPViewerIndirectChildClass)) {
-        this.props.hideViewer();
-      }
+      this.props.hideViewer();
     }
   }
 
@@ -121,12 +120,12 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, Parti
       const attrs = annotation.attributes;
       return (
         <ViewerItem
-            key={annotation.id}
-            annotation={annotation}
-            onDelete={this.onItemDelete}
-            onEdit={this.onItemEdit}
-            // ignore these elements on mouseleave
-            indirectChildClassName={PPViewerIndirectChildClass}
+          key={annotation.id}
+          annotation={annotation}
+          onDelete={this.onItemDelete}
+          onEdit={this.onItemEdit}
+          // ignore these elements on mouseleave
+          indirectChildClassName={PPViewerIndirectChildClass}
         />
       );
     });

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -10,6 +10,7 @@ import styles from './Viewer.scss';
 import { selectViewerState } from 'store/widgets/selectors';
 import { hideViewer, showEditorAnnotation } from 'store/widgets/actions';
 import { AnnotationAPIModel } from 'api/annotations';
+import { PPViewerIndirectChildClass } from 'consts';
 
 interface IViewerProps {
   locationX: number;
@@ -95,9 +96,14 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, Parti
   }
 
   onMouseLeave = (e) => {
-    // Close the window only when the modal is not open
+    // Normally, close the window, except...
+    // not when the modal is not open
     if (!this.state.confirmDeleteModalOpen) {
-      this.props.hideViewer();
+      // check what element the pointer entered;
+      // not when this element is manually marked as an indirect Viewer child (despite not being a DOM child)
+      if (!e.relatedTarget.classList.contains(PPViewerIndirectChildClass)) {
+        this.props.hideViewer();
+      }
     }
   }
 
@@ -115,10 +121,12 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, Parti
       const attrs = annotation.attributes;
       return (
         <ViewerItem
-          key={annotation.id}
-          annotation={annotation}
-          onDelete={this.onItemDelete}
-          onEdit={this.onItemEdit}
+            key={annotation.id}
+            annotation={annotation}
+            onDelete={this.onItemDelete}
+            onEdit={this.onItemEdit}
+            // ignore these elements on mouseleave
+            indirectChildClassName={PPViewerIndirectChildClass}
         />
       );
     });

--- a/src/components/viewer/ViewerItem.tsx
+++ b/src/components/viewer/ViewerItem.tsx
@@ -61,17 +61,7 @@ export default class ViewerItem extends React.Component<Partial<IViewerItemProps
     this.state = {};
   }
 
-  componentWillReceiveProps() {
-    // Set timeout after which edit buttons disappear
-    // In React 16.3 this is legacy method and should theoreticaly be replaced with componentDidUpdate;
-    // However, this won't prevent the timer from firing after the component has been rendered and
-    // before componentDidUpdate is called? Consider submitting an issue to React 16.3
-    if (this.disappearTimeoutId) {
-      clearTimeout(this.disappearTimeoutId);
-    }
-  }
-
-  componentDidUpdate() {
+  componentDidMount() {
     this.disappearTimeoutId = setTimeout(
       () => {
         this.setState({ initialView: false });

--- a/src/components/viewer/ViewerItem.tsx
+++ b/src/components/viewer/ViewerItem.tsx
@@ -21,6 +21,8 @@ import Timer = NodeJS.Timer;
 interface IViewerItemProps {
   key: string;
   annotation: AnnotationAPIModel;
+  indirectChildClassName: string;
+
   hideViewer: () => undefined;
 
   deleteUpvote: (instance: AnnotationUpvoteAPIModel) => Promise<object>;
@@ -181,6 +183,10 @@ export default class ViewerItem extends React.Component<Partial<IViewerItemProps
       createDate,
     } = this.props.annotation.attributes;
 
+    const {
+      indirectChildClassName,
+    } = this.props;
+
     return (
       <li className={styles.annotation}>
         <div className={styles.headBar}>
@@ -206,7 +212,7 @@ export default class ViewerItem extends React.Component<Partial<IViewerItemProps
             <Popup
               trigger={this.upvoteButton()}
               size="small"
-              className="pp-ui pp-popup-small-padding"
+              className={classNames(indirectChildClassName, 'pp-ui', 'pp-popup-small-padding')}
               inverted={true}
             >
               Daj znać, że uważasz przypis za pomocny.

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -5,5 +5,9 @@
  */
 export const PPViewerIndirectChildClass = 'pp-viewer-indirect-child';
 
+export const outsideArticleClasses = [
+  'pp-ui',
+];
+
 // Keep it in sync with css/selection.scss
 export const PPHighlightClass = 'pp-highlight';

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,9 @@
 
+/*
+ * Elements wearing this class will be ignored in viewer mouseleave handling
+ * (their mouseenter will not trigger viewer disappearance)
+ */
+export const PPViewerIndirectChildClass = 'pp-viewer-indirect-child';
+
 // Keep it in sync with css/selection.scss
 export const PPHighlightClass = 'pp-highlight';

--- a/src/core/Highlighter.ts
+++ b/src/core/Highlighter.ts
@@ -1,6 +1,6 @@
-import { Range } from 'xpath-range';
 import $ from 'jquery';
 import { PPHighlightClass } from 'consts';
+import { Range } from 'xpath-range';
 
 /**
  * highlightRange wraps the DOM Nodes within the provided range with a highlight
@@ -39,7 +39,7 @@ function highlightRange(normedRange, cssClass) {
  * reanchorRange will attempt to normalize a range, swallowing Range.RangeErrors
  * for those ranges which are not reanchorable in the current document.
  */
-function reanchorRange(range, rootElement) {
+function reanchorRange(range, rootElement): Range.NormalizedRange {
   const sniffedRange = Range.sniff(range);
   if (sniffedRange) {
     try {
@@ -61,15 +61,23 @@ function reanchorRange(range, rootElement) {
 export interface IHighlightRegistry {
   [id: string]: {
     normedId: string;
-    range: Range.SerializedRange;
+    range: ISerializedRange;
     annotationData: any;
     highlightElements: HTMLElement[];
   };
 }
 
+// pure SerializedRange object with no assumptions on methods
+export interface ISerializedRange {
+  start: string;
+  startOffset: number;
+  end: string;
+  endOffset: number;
+}
+
 interface IHighlightDrawArgs {
   id: number | string;
-  range: Range.NormalizedRange;
+  range: ISerializedRange;
   annotationData: any;
 }
 
@@ -157,7 +165,7 @@ export default class Highlighter {
    *
    *  Returns an Array of drawn highlight elements.
    */
-  draw = (id: number | string, range: Range.SerializedRange, annotationData: any) => {
+  draw = (id: number | string, range: ISerializedRange, annotationData: any) => {
     const normedRange = reanchorRange(range, this.element);
     if (!normedRange) {
       return null;
@@ -231,7 +239,7 @@ export default class Highlighter {
    *
    * Returns the list of newly-drawn highlights.
    */
-  redraw = (id: number | string, range: Range.SerializedRange, annotationData: any) => {
+  redraw = (id: number | string, range: ISerializedRange, annotationData: any) => {
     this.undraw(id);
     return this.draw(id, range, annotationData);
   }

--- a/src/core/Highlighter.ts
+++ b/src/core/Highlighter.ts
@@ -67,16 +67,9 @@ export interface IHighlightRegistry {
   };
 }
 
-interface IRange {
-  start: string;
-  startOffset: number;
-  end: string;
-  endOffset: number;
-}
-
 interface IHighlightDrawArgs {
   id: number | string;
-  range: IRange;
+  range: Range.NormalizedRange;
   annotationData: any;
 }
 

--- a/src/core/TextSelector.ts
+++ b/src/core/TextSelector.ts
@@ -146,7 +146,7 @@ export default class TextSelector {
 
     let isInsideArticle = true;
 
-    // Don't show the adder if the selection was of a part of Annotator itself.
+    // If any part of the selection is outside the article, classify the selection as outside the article
     for (const selectedRange of selectedRanges) {
       let container = selectedRange.commonAncestor;
       if ($(container).hasClass(PPHighlightClass)) {

--- a/src/examples/highlight.ts
+++ b/src/examples/highlight.ts
@@ -20,7 +20,7 @@ function initializeHighlightPlayground() {
 }
 
 function initializeCoreHandlers() {
-  window.textSelector = new TextSelector(document.body, handleSelect);
+  window.textSelector = new TextSelector(document.body, { onMouseUp: handleSelect });
   window.highlighter = new Highlighter(document.body, null);
   window.highlighter.onHighlightEvent('mouseover', (e, annotationData) => {
     console.log(e);

--- a/src/init/handlers.ts
+++ b/src/init/handlers.ts
@@ -12,7 +12,10 @@ let handlers;
 
 export function initializeCoreHandlers() {
   const highlighter = new Highlighter(document.body, null);
-  const selector = new TextSelector(document.body, textSelectorCallback, outsideArticleClasses);
+  const selector = new TextSelector(document.body, {
+    onMouseUp: selectionChangeCallback,
+    outsideArticleClasses,
+  });
 
   handlers = {
     highlighter,
@@ -24,7 +27,7 @@ export function deinitializeCoreHandlers() {
   // ...?
 }
 
-function textSelectorCallback(
+function selectionChangeCallback(
   selection: Range.SerializedRange[],
   isInsideArticle: boolean,
   event) {

--- a/src/init/handlers.ts
+++ b/src/init/handlers.ts
@@ -13,7 +13,7 @@ let handlers;
 export function initializeCoreHandlers() {
   const highlighter = new Highlighter(document.body, null);
   const selector = new TextSelector(document.body, {
-    onMouseUp: selectionChangeCallback,
+    onSelectionChange: selectionChangeCallback,
     outsideArticleClasses,
   });
 

--- a/src/init/handlers.ts
+++ b/src/init/handlers.ts
@@ -6,13 +6,13 @@ import { makeSelection, showMenu } from 'store/actions';
 
 import { Highlighter, TextSelector } from '../core/index';
 import { hideMenu } from 'store/widgets/actions';
-import { noSelection } from 'store/textSelector/actions';
+import { outsideArticleClasses } from '../consts';
 
 let handlers;
 
 export function initializeCoreHandlers() {
   const highlighter = new Highlighter(document.body, null);
-  const selector = new TextSelector(document.body, textSelectorCallback);
+  const selector = new TextSelector(document.body, textSelectorCallback, outsideArticleClasses);
 
   handlers = {
     highlighter,
@@ -24,9 +24,14 @@ export function deinitializeCoreHandlers() {
   // ...?
 }
 
-function textSelectorCallback(selection: Range.SerializedRange[], event) {
-  if (selection.length === 0) {
-    store.dispatch(noSelection());
+function textSelectorCallback(
+  selection: Range.SerializedRange[],
+  isInsideArticle: boolean,
+  event) {
+  if (selection.length === 0 || (selection.length === 1 && !isInsideArticle)) {
+    // Propagate to the store only selections fully inside the article (e.g. not belonging to any of PP components)
+    // When we need to react also to other, we can easily expand the textSelector reducer; for now it' too eager.
+    store.dispatch(makeSelection(null));
     store.dispatch(hideMenu());
   } else if (selection.length === 1) {
     store.dispatch(makeSelection(selection[0]));

--- a/src/store/textSelector/actions.ts
+++ b/src/store/textSelector/actions.ts
@@ -10,12 +10,3 @@ export function makeSelection(range: Range.SerializedRange) {
     },
   };
 }
-
-export function noSelection() {
-  return {
-    type: TEXT_SELECTED,
-    payload: {
-      range: null,
-    },
-  };
-}

--- a/src/store/textSelector/reducers.ts
+++ b/src/store/textSelector/reducers.ts
@@ -7,7 +7,6 @@ const initialState = {
 export default function textSelector(state = initialState, action) {
   switch (action.type) {
     case TEXT_SELECTED:
-      console.log('Handle text selected action, data: ', action.payload);
       return textSelectedActionHandler(state, action.payload);
     default:
       return state;

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -20,17 +20,11 @@ export const showEditorAnnotation = (x: number, y: number, id?: string) => {
   };
 };
 
-// Note: range is explicitly rewritten, so it becomes a pure object (no functions)
 export const setSelectionRange = (range: Range.SerializedRange) => {
   return {
     type: SET_EDITOR_SELECTION_RANGE,
     payload: {
-      range: {
-        start: range.start,
-        startOffset: range.startOffset,
-        end: range.end,
-        endOffset: range.endOffset,
-      },
+      range,
     },
   };
 };


### PR DESCRIPTION
**Main**
- `Viewer` does not disappear on its inner tooltip `mouseover` any more.
- TextSelector: current onSelection renamed to onMouseUp and a new, more selective event `onSelectionChange` (now the one listened to instead of onMouseUp)
- fixed ViewerItem `setState` warning.

**Changes that were a part of a rolled back solution, but are a useful extension for the future, so I decided to keep it**
- extended `TextSelector`: for selections on `.pp-ui` elements, TextSelector passes extra `isInsideArticle` argument instead of returning null on selection.
