### PR TITLE
Viewer mouse events

### DIFF
--- a/src/components/viewer/DeleteAnnotationModal.tsx
+++ b/src/components/viewer/DeleteAnnotationModal.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { deleteResource } from 'redux-json-api';
+import { Button, Modal } from 'semantic-ui-react';
+
+import { selectViewerState } from 'store/widgets/selectors';
+import { hideViewerDeleteModal } from 'store/widgets/actions';
+import { AnnotationAPIModel } from 'api/annotations';
+import { PPScopeClass } from 'class_consts.ts';
+import { mouseOverViewer } from 'store/widgets/actions';
+
+interface IModalProps {
+  deleteModalId: string;
+  deleteModalOpen: boolean;
+
+  annotations: AnnotationAPIModel[];
+
+  deleteAnnotation: (instance: AnnotationAPIModel) => Promise<object>;
+  mouseOverViewer: (value: boolean) => void;
+  hideViewerDeleteModal: () => void;
+}
+
+@connect(
+  (state) => {
+    const {
+      deleteModal: {
+        deleteModalId,
+        deleteModalOpen,
+      },
+      annotations,
+    } = selectViewerState(state);
+
+    return {
+      deleteModalId,
+      deleteModalOpen,
+      annotations,
+    };
+  },
+  {
+    mouseOverViewer,
+    hideViewerDeleteModal,
+    deleteAnnotation: deleteResource,
+  },
+)
+export default class DeleteAnnotationModal extends React.Component<Partial<IModalProps>, {}> {
+
+  handleConfirmDelete = (e) => {
+    const annotation = this.props.annotations.find(a => a.id === this.props.deleteModalId);
+    this.props.deleteAnnotation(annotation)
+      .catch((errors) => {
+        console.log(errors);
+      });
+  }
+
+  handleCancel = (e) => {
+    this.props.hideViewerDeleteModal();
+    this.props.mouseOverViewer(false);
+  }
+
+  render() {
+    return (
+      <Modal
+        size="mini"
+        className={PPScopeClass}
+        open={this.props.deleteModalOpen}
+      >
+        <Modal.Content>
+          <p>Czy na pewno chcesz usunąć przypis?</p>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={this.handleCancel} size="tiny" negative={true}>
+            Nie
+          </Button>
+          <Button onClick={this.handleConfirmDelete} size="tiny" positive={true}>
+            Tak
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    );
+  }
+
+}

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -53,6 +53,7 @@ interface IViewerState {
   },
 )
 export default class Viewer extends React.Component<Partial<IViewerProps>, Partial<IViewerState>> {
+
   static defaultProps = {
     visible: true,
     locationX: 0,

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -3,33 +3,27 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { createResource, deleteResource } from 'redux-json-api';
 import Widget from 'components/widget';
-import { Button, Modal } from 'semantic-ui-react';
 
 import ViewerItem from './ViewerItem';
 import styles from './Viewer.scss';
 import { selectViewerState } from 'store/widgets/selectors';
-import { hideViewer, hideViewerDeleteModal, openViewerDeleteModal, showEditorAnnotation } from 'store/widgets/actions';
+import { hideViewer, openViewerDeleteModal, showEditorAnnotation } from 'store/widgets/actions';
 import { AnnotationAPIModel } from 'api/annotations';
 import { PPScopeClass, PPViewerIndirectChildClass } from 'class_consts.ts';
-import Timer = NodeJS.Timer;
-import Highlighter from 'core/Highlighter';
-import { mouseOverViewer } from '../../store/widgets/actions';
+import { mouseOverViewer } from 'store/widgets/actions';
+import DeleteAnnotationModal from './DeleteAnnotationModal';
 
 interface IViewerProps {
   locationX: number;
   locationY: number;
   annotations: AnnotationAPIModel[];
-  deleteModalId: string;
+
   deleteModalOpen: boolean;
 
-  onModalClose: (Event) => void;
-
-  deleteAnnotation: (instance: AnnotationAPIModel) => Promise<object>;
   showEditorAnnotation: (x: number, y: number, id?: string) => void;
   hideViewer: () => void;
   mouseOverViewer: (value: boolean) => void;
   openViewerDeleteModal: (id: string) => void;
-  hideViewerDeleteModal: () => void;
 }
 
 @connect(
@@ -39,7 +33,6 @@ interface IViewerProps {
       locationX,
       locationY,
       deleteModal: {
-        deleteModalId,
         deleteModalOpen,
       },
       annotations,
@@ -49,7 +42,6 @@ interface IViewerProps {
       visible,
       locationX,
       locationY,
-      deleteModalId,
       deleteModalOpen,
       annotations,
     };
@@ -59,8 +51,6 @@ interface IViewerProps {
     hideViewer,
     mouseOverViewer,
     openViewerDeleteModal,
-    hideViewerDeleteModal,
-    deleteAnnotation: deleteResource,
   },
 )
 export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
@@ -87,19 +77,6 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
 
   onItemDelete = (id: string) => {
     this.props.openViewerDeleteModal(id);
-  }
-
-  onItemConfirmedDelete = (e) => {
-    const annotation = this.props.annotations.find(a => a.id === this.props.deleteModalId);
-    this.props.deleteAnnotation(annotation)
-      .catch((errors) => {
-        console.log(errors);
-      });
-  }
-
-  setDeleteModalClosed = (e) => {
-    this.props.hideViewerDeleteModal();
-    this.props.mouseOverViewer(false);
   }
 
   handleMouseLeave = (e) => {
@@ -133,28 +110,6 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
     });
   }
 
-  renderDeleteModal() {
-    return (
-      <Modal
-        size="mini"
-        className={PPScopeClass}
-        open={this.props.deleteModalOpen}
-      >
-        <Modal.Content>
-          <p>Czy na pewno chcesz usunąć przypis?</p>
-        </Modal.Content>
-        <Modal.Actions>
-          <Button onClick={this.setDeleteModalClosed} size="tiny" negative={true}>
-            Nie
-          </Button>
-          <Button onClick={this.onItemConfirmedDelete} size="tiny" positive={true}>
-            Tak
-          </Button>
-        </Modal.Actions>
-      </Modal>
-    );
-  }
-
   render() {
     return (
       <Widget
@@ -169,7 +124,7 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
         <ul className={styles.annotationItems}>
           {this.renderItems()}
         </ul>
-        {this.renderDeleteModal()}
+        <DeleteAnnotationModal/>
       </Widget>
     );
   }

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -186,7 +186,7 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, Parti
   render() {
     return (
       <Widget
-        className={classNames('pp-ui', styles.self)}
+        className={classNames(PPScopeClass, styles.self)}
         locationX={this.props.locationX}
         locationY={this.props.locationY}
         updateInverted={true}

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -25,6 +25,7 @@ interface IViewerProps {
 
   onMouseLeave: (Event) => void;
   onMouseEnter: (Event) => void;
+  onModalClose: (Event) => void;
 
   deleteAnnotation: (instance: AnnotationAPIModel) => Promise<object>;
   showEditorAnnotation: (x: number, y: number, id?: string) => void;
@@ -33,11 +34,6 @@ interface IViewerProps {
   hideViewerDeleteModal: () => void;
 }
 
-/*
- * TODO list
- * - [roadmap 6.1.4] the appear/disappear logic of Viewer is just a simulation and should be refined or
-  * (preferably) straightforwardly adapted from old_src/ViewerWidget
- */
 @connect(
   (state) => {
     const {
@@ -103,9 +99,8 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
   }
 
   setDeleteModalClosed = (e) => {
-    // todo: in the future we should handle the case when the modal has just been closed and
-    // the cursor is outside the viewer (so it never actually leaves the viewer area)
     this.props.hideViewerDeleteModal();
+    this.props.onModalClose(e);
   }
 
   renderItems() {

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -13,6 +13,7 @@ import { AnnotationAPIModel } from 'api/annotations';
 import { PPScopeClass, PPViewerIndirectChildClass } from 'class_consts.ts';
 import Timer = NodeJS.Timer;
 import Highlighter from 'core/Highlighter';
+import { mouseOverViewer } from '../../store/widgets/actions';
 
 interface IViewerProps {
   locationX: number;
@@ -21,15 +22,12 @@ interface IViewerProps {
   deleteModalId: string;
   deleteModalOpen: boolean;
 
-  highlighter: Highlighter;
-
-  onMouseLeave: (Event) => void;
-  onMouseEnter: (Event) => void;
   onModalClose: (Event) => void;
 
   deleteAnnotation: (instance: AnnotationAPIModel) => Promise<object>;
   showEditorAnnotation: (x: number, y: number, id?: string) => void;
   hideViewer: () => void;
+  mouseOverViewer: (value: boolean) => void;
   openViewerDeleteModal: (id: string) => void;
   hideViewerDeleteModal: () => void;
 }
@@ -59,6 +57,7 @@ interface IViewerProps {
   {
     showEditorAnnotation,
     hideViewer,
+    mouseOverViewer,
     openViewerDeleteModal,
     hideViewerDeleteModal,
     deleteAnnotation: deleteResource,
@@ -100,7 +99,22 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
 
   setDeleteModalClosed = (e) => {
     this.props.hideViewerDeleteModal();
-    this.props.onModalClose(e);
+    this.props.mouseOverViewer(false);
+  }
+
+  handleMouseLeave = (e) => {
+    // Normally, close the window, except...
+    // not when the modal is not open
+    // not when this element is manually marked as an indirect Viewer child (despite not being a DOM child)
+    const isMouseOverIndirectChild = e.relatedTarget.classList.contains(PPViewerIndirectChildClass);
+    if (!this.props.deleteModalOpen && !isMouseOverIndirectChild) {
+      // check what element the pointer entered;
+      this.props.mouseOverViewer(false);
+    }
+  }
+
+  handleMouseEnter = (e) => {
+    this.props.mouseOverViewer(true);
   }
 
   renderItems() {
@@ -149,8 +163,8 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
         locationY={this.props.locationY}
         updateInverted={true}
         widgetTriangle={true}
-        onMouseLeave={this.props.onMouseLeave}
-        onMouseEnter={this.props.onMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+        onMouseEnter={this.handleMouseEnter}
       >
         <ul className={styles.annotationItems}>
           {this.renderItems()}

--- a/src/components/viewer/ViewerManager.tsx
+++ b/src/components/viewer/ViewerManager.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { createResource, deleteResource } from 'redux-json-api';
+import Widget from 'components/widget';
+import { Button, Modal } from 'semantic-ui-react';
+
+import ViewerItem from './ViewerItem';
+import styles from './Viewer.scss';
+import { selectViewerState } from 'store/widgets/selectors';
+import { hideViewer, showEditorAnnotation } from 'store/widgets/actions';
+import { AnnotationAPIModel } from 'api/annotations';
+import { PPScopeClass, PPViewerIndirectChildClass } from 'class_consts.ts';
+import Timer = NodeJS.Timer;
+import Highlighter from 'core/Highlighter';
+import Viewer from './Viewer';
+import _isEqual from 'lodash/isEqual';
+
+interface IViewerManagerProps {
+  visible: boolean;
+  deleteModalOpen: boolean;
+  annotationIds: string[];
+
+  highlighter: Highlighter;
+
+  hideViewer: () => void;
+  showViewer: () => void;
+}
+
+@connect(
+  (state) => {
+    const {
+      visible,
+      deleteModal: {
+        deleteModalOpen,
+      },
+      annotationIds,
+    } = selectViewerState(state);
+
+    return {
+      visible,
+      deleteModalOpen,
+      annotationIds,
+    };
+  },
+  {
+    hideViewer,
+  },
+)
+export default class ViewerManager extends React.Component<Partial<IViewerManagerProps>, {}> {
+  /*
+   * ViewerManager purpose is to centrally manage mouse events, both related to Viewer widget and highlight-related .
+   * (note: Especially the latter couldn't be correctly done by a Viewer that is mounted on
+   * the highlight mouseover event, since Viewer could not subscribe to highlight mouseleave event quickly enough
+   * -- before the pointer leaves it. It was the first attempted solution and quick mouse movements were in fact
+   * not captured)
+   *
+   * Highlighter component is provided from the outside and lets ViewerManager subscribe directly
+   * to highlight mouse events.
+   */
+
+  static mouseleaveDisappearTimeout = 200;
+
+  static defaultProps = {
+    visible: true,
+    deleteModalOpen: false,
+  };
+
+  disappearTimeoutId: Timer;
+
+  constructor(props: IViewerManagerProps) {
+    super(props);
+  }
+
+  componentDidMount() {
+    this.props.highlighter.onHighlightEvent('mouseover', this.onHighlightMouseover);
+    this.props.highlighter.onHighlightEvent('mouseleave', this.onHighlightMouseleave);
+  }
+
+  componentWillUnmount() {
+    this.clearDisappearTimer();
+  }
+
+  onHighlightMouseover = (e, annotations) => {
+    this.clearDisappearTimer();
+  }
+
+  onHighlightMouseleave = (e, annotations) => {
+    const eventAnnotations = annotations.map(ann => ann.id);
+    // Make sure the leave event is up-to-date
+    if (_isEqual(eventAnnotations, this.props.annotationIds)) {
+      this.startDisappearTimer();
+    }
+  }
+
+  startDisappearTimer() {
+    // clear the timer so more than one cannot accumulate
+    this.clearDisappearTimer();
+    this.disappearTimeoutId = setTimeout(
+      () => {
+        this.disappearTimeoutId = null;
+        this.props.hideViewer();
+      },
+      ViewerManager.mouseleaveDisappearTimeout,
+    );
+  }
+
+  clearDisappearTimer() {
+    if (this.disappearTimeoutId) {
+      clearTimeout(this.disappearTimeoutId);
+      this.disappearTimeoutId = null;
+    }
+  }
+
+  onMouseLeave = (e) => {
+    // Normally, close the window, except...
+    // not when the modal is not open
+    // not when this element is manually marked as an indirect Viewer child (despite not being a DOM child)
+    const isMouseOverIndirectChild = e.relatedTarget.classList.contains(PPViewerIndirectChildClass);
+    if (!this.props.deleteModalOpen && !isMouseOverIndirectChild) {
+      // check what element the pointer entered;
+      this.startDisappearTimer();
+    }
+  }
+
+  onMouseEnter = (e) => {
+    this.clearDisappearTimer();
+  }
+
+  render() {
+    if (this.props.visible) {
+      return (
+        <Viewer
+          onMouseLeave={this.onMouseLeave}
+          onMouseEnter={this.onMouseEnter}
+        />
+      );
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/components/widget/Widget.tsx
+++ b/src/components/widget/Widget.tsx
@@ -18,6 +18,7 @@ export interface IWidgetProps {
 
   className: string;
   onMouseLeave: (Event) => void;
+  onMouseEnter: (Event) => void;
   children: React.ReactChild | React.ReactChild[];
 }
 
@@ -54,6 +55,7 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
     updateInverted: false,
     className: '',
     onMouseLeave: null,
+    onMouseEnter: null,
     widgetTriangle: false,
   };
 
@@ -114,6 +116,7 @@ export default class Widget extends React.PureComponent<Partial<IWidgetProps>,
     const inner = this.innerElement.current;
     if (inner) {
       inner.addEventListener('mouseleave', this.props.onMouseLeave);
+      inner.addEventListener('mouseenter', this.props.onMouseEnter);
     }
 
     if (this.state.updateInverted) {

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -3,7 +3,6 @@ import Menu from 'components/menu';
 import Viewer from 'components/viewer';
 import Editor from 'components/editor';
 import { connect } from 'react-redux';
-import { handlers } from '../init/handlers';
 import ViewerManager from '../components/viewer/ViewerManager';
 
 interface AppProps {
@@ -27,7 +26,7 @@ export default class App extends React.Component<Partial<AppProps>> {
       <div>
         {this.props.editor.visible && <Editor/>}
         {this.props.menuVisible && <Menu/>}
-        <ViewerManager highlighter={handlers.highlighter}/>
+        <ViewerManager/>
       </div>
     );
   }

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -3,6 +3,8 @@ import Menu from 'components/menu';
 import Viewer from 'components/viewer';
 import Editor from 'components/editor';
 import { connect } from 'react-redux';
+import { handlers } from '../init/handlers';
+import ViewerManager from '../components/viewer/ViewerManager';
 
 interface AppProps {
   editor: any;
@@ -24,8 +26,8 @@ export default class App extends React.Component<Partial<AppProps>> {
     return (
       <div>
         {this.props.editor.visible && <Editor/>}
-        {this.props.viewerVisible && <Viewer/>}
         {this.props.menuVisible && <Menu/>}
+        <ViewerManager highlighter={handlers.highlighter}/>
       </div>
     );
   }

--- a/src/init/handlers.ts
+++ b/src/init/handlers.ts
@@ -9,7 +9,7 @@ import { hideMenu } from 'store/widgets/actions';
 import { outsideArticleClasses } from 'class_consts';
 import highlights from './highlights';
 
-export let handlers;
+let handlers;
 
 export function initializeCoreHandlers() {
   const highlighter = new Highlighter(document.body);

--- a/src/init/handlers.ts
+++ b/src/init/handlers.ts
@@ -9,7 +9,7 @@ import { hideMenu } from 'store/widgets/actions';
 import { outsideArticleClasses } from 'class_consts';
 import highlights from './highlights';
 
-let handlers;
+export let handlers;
 
 export function initializeCoreHandlers() {
   const highlighter = new Highlighter(document.body);

--- a/src/init/highlights.ts
+++ b/src/init/highlights.ts
@@ -2,6 +2,7 @@ import store from 'store';
 import { showViewer } from 'store/actions';
 import { mousePosition } from 'common/dom';
 import Highlighter from 'core/Highlighter';
+import { mouseOverViewer } from '../store/widgets/actions';
 
 let instance;
 let mouseDown = false;
@@ -20,7 +21,8 @@ function onMouseUp(e: MouseEvent) {
 
 function init(highlighter: Highlighter) {
   // This event subscription will last irrespective of whether annotations are redrawn or not
-  highlighter.onHighlightEvent('mouseover', handleHighlightEvent);
+  highlighter.onHighlightEvent('mouseover', handleHighlightMouseEnter);
+  highlighter.onHighlightEvent('mouseleave', handleHighlightMouseLeave);
 
   // Watch mouse button state;
   document.body.addEventListener('mousedown', onMouseDown);
@@ -58,7 +60,11 @@ function drawHighlights() {
   })));
 }
 
-function handleHighlightEvent(e, annotations) {
+function handleHighlightMouseLeave(e, annotations) {
+  store.dispatch(mouseOverViewer(false));
+}
+
+function handleHighlightMouseEnter(e, annotations) {
   // If the mouse button is currently depressed, we're probably trying to
   // make a selection, so we shouldn't show the viewer.
   if (mouseDown) {

--- a/src/init/highlights.ts
+++ b/src/init/highlights.ts
@@ -5,28 +5,11 @@ import Highlighter from 'core/Highlighter';
 import { mouseOverViewer } from '../store/widgets/actions';
 
 let instance;
-let mouseDown = false;
-
-function onMouseDown(e: MouseEvent) {
-  if (e.button === 0) {
-    mouseDown = true;
-  }
-}
-
-function onMouseUp(e: MouseEvent) {
-  if (e.button === 0) {
-    mouseDown = false;
-  }
-}
 
 function init(highlighter: Highlighter) {
   // This event subscription will last irrespective of whether annotations are redrawn or not
   highlighter.onHighlightEvent('mouseover', handleHighlightMouseEnter);
   highlighter.onHighlightEvent('mouseleave', handleHighlightMouseLeave);
-
-  // Watch mouse button state;
-  document.body.addEventListener('mousedown', onMouseDown);
-  document.body.addEventListener('mouseup', onMouseUp);
 
   // subscribe to store changes and return unsubscribe fn
   const unsubscribe = store.subscribe(drawHighlights);
@@ -40,8 +23,6 @@ function init(highlighter: Highlighter) {
 
 function deinit() {
   instance.unsubscribe();
-  document.body.addEventListener('mousedown', onMouseDown);
-  document.body.addEventListener('mouseup', onMouseUp);
 }
 
 function drawHighlights() {
@@ -61,13 +42,16 @@ function drawHighlights() {
 }
 
 function handleHighlightMouseLeave(e, annotations) {
+  if (e.buttons !== 0) {
+    return;
+  }
   store.dispatch(mouseOverViewer(false));
 }
 
 function handleHighlightMouseEnter(e, annotations) {
   // If the mouse button is currently depressed, we're probably trying to
   // make a selection, so we shouldn't show the viewer.
-  if (mouseDown) {
+  if (e.buttons !== 0) {
     return;
   }
   const position = mousePosition(e);

--- a/src/init/highlights.ts
+++ b/src/init/highlights.ts
@@ -4,10 +4,27 @@ import { mousePosition } from 'common/dom';
 import Highlighter from 'core/Highlighter';
 
 let instance;
+let mouseDown = false;
+
+function onMouseDown(e: MouseEvent) {
+  if (e.button === 0) {
+    mouseDown = true;
+  }
+}
+
+function onMouseUp(e: MouseEvent) {
+  if (e.button === 0) {
+    mouseDown = false;
+  }
+}
 
 function init(highlighter: Highlighter) {
   // This event subscription will last irrespective of whether annotations are redrawn or not
   highlighter.onHighlightEvent('mouseover', handleHighlightEvent);
+
+  // Watch mouse button state;
+  document.body.addEventListener('mousedown', onMouseDown);
+  document.body.addEventListener('mouseup', onMouseUp);
 
   // subscribe to store changes and return unsubscribe fn
   const unsubscribe = store.subscribe(drawHighlights);
@@ -21,6 +38,8 @@ function init(highlighter: Highlighter) {
 
 function deinit() {
   instance.unsubscribe();
+  document.body.addEventListener('mousedown', onMouseDown);
+  document.body.addEventListener('mouseup', onMouseUp);
 }
 
 function drawHighlights() {
@@ -40,6 +59,11 @@ function drawHighlights() {
 }
 
 function handleHighlightEvent(e, annotations) {
+  // If the mouse button is currently depressed, we're probably trying to
+  // make a selection, so we shouldn't show the viewer.
+  if (mouseDown) {
+    return;
+  }
   const position = mousePosition(e);
   store.dispatch(showViewer(
     position.x,

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -4,6 +4,7 @@ export const EDITOR_ANNOTATION = 'EDITOR_ANNOTATION';
 export const SET_EDITOR_SELECTION_RANGE = 'SET_EDITOR_SELECTION_RANGE';
 export const EDITOR_VISIBLE_CHANGE = 'EDITOR_VISIBLE_CHANGE';
 export const VIEWER_VISIBLE_CHANGE = 'VIEWER_VISIBLE_CHANGE';
+export const VIEWER_MODAL_CHANGE = 'VIEWER_MODAL_CHANGE';
 export const MENU_WIDGET_CHANGE = 'MENU_WIDGET_CHANGE';
 
 export const showEditorAnnotation = (x: number, y: number, id?: string) => {
@@ -66,6 +67,7 @@ export const showViewer = (x: number, y: number, annotationIds: number[]) => {
     payload: {
       annotationIds,
       visible: true,
+      deleteModal: {},
       location: {
         x,
         y,
@@ -79,6 +81,26 @@ export const hideViewer = () => {
     type: VIEWER_VISIBLE_CHANGE,
     payload: {
       visible: false,
+    },
+  };
+};
+
+export const openViewerDeleteModal = (id: string) => {
+  return {
+    type: VIEWER_MODAL_CHANGE,
+    payload: {
+      deleteModalOpen: true,
+      deleteModalId: id,
+    },
+  };
+};
+
+export const hideViewerDeleteModal = () => {
+  return {
+    type: VIEWER_MODAL_CHANGE,
+    payload: {
+      deleteModalOpen: false,
+      deleteModalId: null,
     },
   };
 };

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -67,6 +67,7 @@ export const showViewer = (x: number, y: number, annotationIds: number[]) => {
     payload: {
       annotationIds,
       visible: true,
+      mouseOver: true,
       deleteModal: {},
       location: {
         x,
@@ -81,6 +82,15 @@ export const hideViewer = () => {
     type: VIEWER_VISIBLE_CHANGE,
     payload: {
       visible: false,
+    },
+  };
+};
+
+export const mouseOverViewer = (value: boolean) => {
+  return {
+    type: VIEWER_VISIBLE_CHANGE,
+    payload: {
+      mouseOver: value,
     },
   };
 };

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -2,7 +2,7 @@ import {
   EDITOR_ANNOTATION,
   EDITOR_VISIBLE_CHANGE,
   MENU_WIDGET_CHANGE,
-  SET_EDITOR_SELECTION_RANGE,
+  SET_EDITOR_SELECTION_RANGE, VIEWER_MODAL_CHANGE,
   VIEWER_VISIBLE_CHANGE,
 } from './actions';
 import _difference from 'lodash/difference';
@@ -51,7 +51,7 @@ const widgets = combineReducers({
 });
 export default widgets;
 
-function viewer(state = { ...initialWidgetState, annotationIds: [] } , action) {
+function viewer(state = { ...initialWidgetState, annotationIds: [], deleteModal: {} } , action) {
   switch (action.type) {
     case VIEWER_VISIBLE_CHANGE:
       // Update location only when the displayed annotations have changed, too.
@@ -68,6 +68,11 @@ function viewer(state = { ...initialWidgetState, annotationIds: [] } , action) {
         ...state,
         ...action.payload,
         ...locationOverride,
+      };
+    case VIEWER_MODAL_CHANGE:
+      return {
+        ...state,
+        deleteModal: action.payload,
       };
     case API_DELETED:
       // If one of viewed annotation is removed, filter it out

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -57,5 +57,6 @@ export const selectViewerState = createSelector<IStore, any, any, any>(
     annotations: selectViewerAnnotations(annotations, viewer.annotationIds),
     annotationIds: viewer.annotationIds,
     deleteModal: viewer.deleteModal,
+    mouseOver: viewer.mouseOver,
   }),
 );

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -55,5 +55,7 @@ export const selectViewerState = createSelector<IStore, any, any, any>(
   (viewer, annotations) => ({
     ...selectWidgetState(viewer),
     annotations: selectViewerAnnotations(annotations, viewer.annotationIds),
+    annotationIds: viewer.annotationIds,
+    deleteModal: viewer.deleteModal,
   }),
 );


### PR DESCRIPTION
Fixes #67 

- moved Viewer component modal state to global viewer state
- `ViewerManager`
    - We need to continuously listen to the highlight mouse events related to Viewer. Otherwise, if the `mouseleave` is subscribed to as late as on Viewer mounting, we can (and do, in practice) miss a highlight `mouseleave` event. ViewerManager is always mounted and manages Viewer visibility.
     - `ViewerManager` manages timers related to highlight/viewer `mouseenter` and `mousleave` events. (that can cancel each other out)
- We control the case when the delete confirmation modal has just been closed and the mouse is outside Viewer; we wait for a while and then close viewer.