### PR TITLE
App modes details + popup modifications

### DIFF
--- a/src/browser-extension/popup/BrowserPopup.tsx
+++ b/src/browser-extension/popup/BrowserPopup.tsx
@@ -111,16 +111,26 @@ export default class BrowserPopup extends React.Component<{}, Partial<IBrowserPo
     const {
       disabledPages,
       currentTabUrl,
+      annotationModePages,
     } = this.state;
 
-    let newDisabledList;
+    let newDisabledPages;
     if (checked) {
-      newDisabledList = [...disabledPages, currentTabUrl];
+      newDisabledPages = [...disabledPages, currentTabUrl];
     } else {
-      newDisabledList = _filter(disabledPages, url => url !== currentTabUrl);
+      newDisabledPages = _filter(disabledPages, url => url !== currentTabUrl);
     }
-    this.setState({ disabledPages: newDisabledList });
-    chromeStorage.set({ [chromeKeys.DISABLED_PAGES]: newDisabledList });
+    // Permanently turn off the annotation mode for the disabled pages
+    const newAnnotationModePages = _filter(annotationModePages, url => !newDisabledPages.includes(url));
+
+    this.setState({
+      disabledPages: newDisabledPages,
+      annotationModePages: newAnnotationModePages,
+    });
+    chromeStorage.set({
+      [chromeKeys.DISABLED_PAGES]: newDisabledPages,
+      [chromeKeys.ANNOTATION_MODE_PAGES]: newAnnotationModePages,
+    });
   }
 
   render() {

--- a/src/browser-extension/popup/BrowserPopup.tsx
+++ b/src/browser-extension/popup/BrowserPopup.tsx
@@ -140,13 +140,15 @@ export default class BrowserPopup extends React.Component<{}, Partial<IBrowserPo
     return (
       <div className="pp-popup">
         <ul className="menu">
-          <li
-            className={classNames('menu__item', 'clickable', { disabled: isAnnotationMode })}
-            onClick={this.handleAnnotationModeClick}
-          >
-            <img className="menu__item__icon" src={addIcon}/>
-            <a>Dodaj przypis</a>
-          </li>
+          {
+            <li
+              className={classNames('menu__item', 'clickable',
+                { disabled: isAnnotationMode || isExtensionDisabled || isCurrentPageDisabled })}
+              onClick={this.handleAnnotationModeClick}
+            >
+              <img className="menu__item__icon" src={addIcon}/>
+              <a>Dodaj przypis</a>
+            </li>}
           <li className="menu__item clickable">
             <img className="menu__item__icon" src={requestIcon}/>
             <a>Poproś o przypis</a>

--- a/src/browser-extension/popup/BrowserPopup.tsx
+++ b/src/browser-extension/popup/BrowserPopup.tsx
@@ -150,18 +150,13 @@ export default class BrowserPopup extends React.Component<{}, Partial<IBrowserPo
     return (
       <div className="pp-popup">
         <ul className="menu">
-          {
-            <li
-              className={classNames('menu__item', 'clickable',
-                { disabled: isAnnotationMode || isExtensionDisabled || isCurrentPageDisabled })}
-              onClick={this.handleAnnotationModeClick}
-            >
-              <img className="menu__item__icon" src={addIcon}/>
-              <a>Dodaj przypis</a>
-            </li>}
-          <li className="menu__item clickable">
-            <img className="menu__item__icon" src={requestIcon}/>
-            <a>Poproś o przypis</a>
+          <li
+            className={classNames('menu__item', 'clickable',
+              { disabled: isAnnotationMode || isExtensionDisabled || isCurrentPageDisabled })}
+            onClick={this.handleAnnotationModeClick}
+          >
+            <img className="menu__item__icon" src={addIcon}/>
+            <a>Dodaj przypis</a>
           </li>
           <hr className="menu__separator"/>
           <li className="menu__item">
@@ -179,10 +174,6 @@ export default class BrowserPopup extends React.Component<{}, Partial<IBrowserPo
               onChange={this.handleDisabledPageChange}
             />
           </li>
-          <hr className="menu__separator"/>
-          <div className="cta-container">
-            <button className="cta-button">Daj znać, co myślisz</button>
-          </div>
         </ul>
       </div>
     );

--- a/src/browser-extension/popup/popup.scss
+++ b/src/browser-extension/popup/popup.scss
@@ -60,27 +60,4 @@ body {
     }
 
   }
-
-  .cta-container {
-    padding: 10px 0;
-    display: flex;
-    justify-content: center;
-  }
-
-    .cta-button {
-      margin: 0;
-      font-size: 11px;
-      text-transform: uppercase;
-      cursor: pointer;
-      outline: inherit;
-      display: inline-block;
-      padding: 8px 12px;
-      background-color: #2ecc71;
-      box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 2px 2px 0 rgba(0,0,0,0.24);
-      border-radius: 2px;
-      color: #FFFFFF;
-      letter-spacing: 0.5px;
-      text-align: center;
-    }
-
 }

--- a/src/chrome-storage/index.ts
+++ b/src/chrome-storage/index.ts
@@ -1,4 +1,4 @@
-import { AppModeReducer } from '../store/appModes/reducers';
+import { AppModes } from '../store/appModes/types';
 import _filter from 'lodash/filter';
 import * as chromeKeys from './keys';
 import { standardizeUrlForPageSettings } from 'utils/url';
@@ -35,7 +35,7 @@ if (typeof chrome.storage !== 'undefined') {
 
 export default storage;
 
-export function turnOffAnnotationMode(appModes: AppModeReducer) {
+export function turnOffAnnotationMode(appModes: AppModes) {
   const currentStandardizedURL = standardizeUrlForPageSettings(window.location.href);
   const newAnnotationModePages = _filter(appModes.annotationModePages, url => url !== currentStandardizedURL);
   storage.set({ [chromeKeys.ANNOTATION_MODE_PAGES]: newAnnotationModePages });

--- a/src/components/annotationModeWidget/AnnotationModeWidget.scss
+++ b/src/components/annotationModeWidget/AnnotationModeWidget.scss
@@ -1,4 +1,5 @@
 @import "css/common/vars/fonts";
+@import "css/common/vars/z-index";
 @import "css/common/mixins";
 
 /* -- PP Action menu -- */
@@ -7,7 +8,7 @@
   top: 20px;
   right: 20px;
   width: 270px;
-  z-index: 10;
+  z-index: $annotation-mode-widget-z-index;
   padding: 20px 10px;
 
   font-size: 14px;

--- a/src/components/annotationModeWidget/AnnotationModeWidget.tsx
+++ b/src/components/annotationModeWidget/AnnotationModeWidget.tsx
@@ -5,10 +5,10 @@ import classNames from 'classnames';
 import styles from './AnnotationModeWidget.scss';
 import { PPScopeClass } from '../../class_consts';
 import { turnOffAnnotationMode } from '../../chrome-storage';
-import { AppModeReducer } from '../../store/appModes/reducers';
+import { AppModes } from 'store/appModes/types';
 
 export interface IAnnotationModeWidgetProps {
-  appModes: AppModeReducer;
+  appModes: AppModes;
 }
 
 @connect(

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -18,10 +18,10 @@ import { PPScopeClass } from 'class_consts.ts';
 import { isValidUrl } from '../../utils/url';
 import { turnOffAnnotationMode } from '../../chrome-storage';
 import { IEditorRange } from 'store/widgets/reducers';
-import { AppModeReducer } from '../../store/appModes/reducers';
+import { AppModes } from '../../store/appModes/types';
 
 interface IEditorProps {
-  appModes: AppModeReducer;
+  appModes: AppModes;
 
   locationX: number;
   locationY: number;

--- a/src/css/common/vars/z-index.scss
+++ b/src/css/common/vars/z-index.scss
@@ -10,3 +10,5 @@ $editor-z-index: $z-index-base + 20;
 // editor-z-index + 1 = editor's tooltips and errors
 
 $menu-z-index: $z-index-base + 30;
+
+$annotation-mode-widget-z-index: $z-index-base;

--- a/src/init/chromeStorageHandlers.ts
+++ b/src/init/chromeStorageHandlers.ts
@@ -1,7 +1,7 @@
 import * as chromeKeys from '../chrome-storage/keys';
 import { changeAppModes } from '../store/appModes/actions';
 import store from '../store';
-import { AppModeReducer } from '../store/appModes/reducers';
+import { AppModes } from 'store/appModes/types';
 import chromeStorage from 'chrome-storage';
 
 const storageKeysToAppMode = {
@@ -14,7 +14,7 @@ export default function initializeChromeStorageHandlers() {
   chromeStorage.onChanged.addListener((changes, namespace) => {
     for (const key of Object.keys(changes)) {
       store.dispatch(
-        changeAppModes({ [storageKeysToAppMode[key]]: changes[key].newValue } as AppModeReducer),
+        changeAppModes({ [storageKeysToAppMode[key]]: changes[key].newValue } as AppModes),
       );
     }
   });

--- a/src/store/appModes/actions.ts
+++ b/src/store/appModes/actions.ts
@@ -1,8 +1,8 @@
-import { AppModeReducer } from './reducers';
+import { AppModes } from './types';
 
 export const MODIFY_APP_MODES = 'MODIFY_APP_MODES';
 
-export function changeAppModes(appModes: AppModeReducer) {
+export function changeAppModes(appModes: AppModes) {
   return {
     type: MODIFY_APP_MODES,
     payload: {

--- a/src/store/appModes/reducers.ts
+++ b/src/store/appModes/reducers.ts
@@ -1,12 +1,7 @@
 import { MODIFY_APP_MODES } from './actions';
+import { AppModes } from './types';
 
-export interface AppModeReducer {
-  isExtensionDisabled: boolean;
-  annotationModePages: string[];
-  disabledPages: string[];
-}
-
-const initialState: AppModeReducer = {
+const initialState: AppModes = {
   isExtensionDisabled: false,
   annotationModePages: [],
   disabledPages: [],

--- a/src/store/appModes/selectors.ts
+++ b/src/store/appModes/selectors.ts
@@ -1,13 +1,18 @@
 import { createSelector } from 'reselect';
 import { ITabState } from 'store/reducer';
 import { standardizeUrlForPageSettings } from 'utils/url';
+import { AppModes } from './types';
+
+export function isAnnotationMode(appModes: AppModes) {
+  const currentStandardizedUrl = standardizeUrlForPageSettings(window.location.href);
+  return (appModes.annotationModePages || []).includes(currentStandardizedUrl) && !appModes.isExtensionDisabled;
+}
 
 export const selectModeForCurrentPage = createSelector<ITabState, any, any>(
   state => state.appModes,
   (appModes) => {
     // Standardize the URL by disregarding stuff that does not identify a page like URL parameters etc.
     const currentStandardizedUrl = standardizeUrlForPageSettings(window.location.href);
-    console.log(appModes.disabledPages.includes(currentStandardizedUrl));
     return {
       // Page highlights are disabled when
       //  the extension is disabled in general or when it is disabled for this particular page
@@ -16,8 +21,7 @@ export const selectModeForCurrentPage = createSelector<ITabState, any, any>(
       // Annotation mode is on when
       // - the current URL is included in annotationModePages
       // - the extension is not globally disabled
-      isAnnotationMode: appModes.annotationModePages.includes(currentStandardizedUrl)
-      && !appModes.isExtensionDisabled,
+      isAnnotationMode: isAnnotationMode(appModes),
     };
   },
 );

--- a/src/store/appModes/selectors.ts
+++ b/src/store/appModes/selectors.ts
@@ -7,14 +7,17 @@ export const selectModeForCurrentPage = createSelector<ITabState, any, any>(
   (appModes) => {
     // Standardize the URL by disregarding stuff that does not identify a page like URL parameters etc.
     const currentStandardizedUrl = standardizeUrlForPageSettings(window.location.href);
-
+    console.log(appModes.disabledPages.includes(currentStandardizedUrl));
     return {
-    // Page highlights are disabled when
-    //  the extension is disabled in general or when it is disabled for this particular page
+      // Page highlights are disabled when
+      //  the extension is disabled in general or when it is disabled for this particular page
       arePageHighlightsDisabled: appModes.isExtensionDisabled
       || appModes.disabledPages.indexOf(currentStandardizedUrl) !== -1,
-      // Annotation mode is on when the current URL
-      isAnnotationMode: appModes.annotationModePages.indexOf(currentStandardizedUrl) !== -1,
+      // Annotation mode is on when
+      // - the current URL is included in annotationModePages
+      // - the extension is not globally disabled
+      isAnnotationMode: appModes.annotationModePages.includes(currentStandardizedUrl)
+      && !appModes.isExtensionDisabled,
     };
   },
 );

--- a/src/store/appModes/types.ts
+++ b/src/store/appModes/types.ts
@@ -1,0 +1,5 @@
+export interface AppModes {
+  isExtensionDisabled: boolean;
+  annotationModePages: string[];
+  disabledPages: string[];
+}

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -1,7 +1,8 @@
 import { combineReducers } from 'redux';
 import { reducer as api } from 'redux-json-api';
 import widgets, { WidgetReducer } from './widgets/reducers';
-import appModes, { AppModeReducer } from './appModes/reducers';
+import { AppModes } from './appModes/types';
+import appModes from './appModes/reducers';
 import textSelector from './textSelector/reducers';
 import { AnnotationAPIModel } from 'api/annotations';
 import { AnnotationUpvoteAPIModel } from 'api/annotation-upvotes';
@@ -11,7 +12,7 @@ export interface ITabState {
     annotations: { data: AnnotationAPIModel[] };
     annotationUpvotes: { data: AnnotationUpvoteAPIModel[] };
   };
-  appModes: AppModeReducer;
+  appModes: AppModes;
   widgets: WidgetReducer;
   textSelector: any;
 }

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -9,10 +9,12 @@ import _difference from 'lodash/difference';
 import { API_DELETED } from 'redux-json-api/lib/constants';
 import { AnnotationResourceType } from 'api/annotations';
 import { combineReducers } from 'redux';
+import { MODIFY_APP_MODES } from '../appModes/actions';
+import { isAnnotationMode } from 'store/appModes/selectors';
 
 export interface IWidgetState {
   visible: boolean;
-  location: {x: number; y: number};
+  location: { x: number; y: number };
 }
 
 export interface IViewerState extends IWidgetState {
@@ -51,7 +53,7 @@ const widgets = combineReducers({
 });
 export default widgets;
 
-function viewer(state = { ...initialWidgetState, annotationIds: [], deleteModal: {} } , action) {
+function viewer(state = { ...initialWidgetState, annotationIds: [], deleteModal: {} }, action) {
   switch (action.type) {
     case VIEWER_VISIBLE_CHANGE:
       // Update location only when the displayed annotations have changed, too.
@@ -95,7 +97,7 @@ function viewer(state = { ...initialWidgetState, annotationIds: [], deleteModal:
   }
 }
 
-function menu(state = initialWidgetState , action) {
+function menu(state = initialWidgetState, action) {
   switch (action.type) {
     case MENU_WIDGET_CHANGE:
       return { ...state, ...action.payload };
@@ -110,6 +112,12 @@ function editor(state = { annotationId: null, range: null, ...initialWidgetState
     case EDITOR_ANNOTATION:
     case SET_EDITOR_SELECTION_RANGE:
       return { ...state, ...action.payload };
+    case MODIFY_APP_MODES:
+      // When the annotation mode is turned off, editor is closed
+      return {
+        ...state,
+        visible: state.visible && isAnnotationMode(action.payload),
+      };
     default:
       return state;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,10 @@
       "./@types",
       "./node_modules/@types"
     ],
+    "lib": [
+      "dom",
+      "es7"
+    ],
     "baseUrl": ".",
     "paths": {
       "*": [


### PR DESCRIPTION
Resolves #124 
Some uncertainties still had to be resolved. Final solution I found reasonable within our constraints:
- annotation mode cannot be turned on when the extension is disabled (globally or on this page)
- when the extension is disabled on a page, annotation mode is **permanently** turned off
- when the extension is disabled globally, annotation mode is **_temporarily_** turned off
- when the annotation mode is turned off, open Editor disappears.

Besides
- included "es7" lib in tsconfig so `Array.includes` does not throw TS errors

Resolves #126 
- additionally, increased annotation mode widget's z-index so it's displayed above all typical websites.