### PR TITLE
Pass quote text to backend when creating annotation

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -35,6 +35,7 @@ interface IEditorProps {
 
   annotation: AnnotationAPIModel;
   range: IEditorRange;
+  text: string;
 
   createOrUpdateAnnotation: (instance: AnnotationAPICreateModel) => Promise<object>;
   hideEditor: () => void;
@@ -47,6 +48,8 @@ interface IEditorState {
   annotationLink: string;
   annotationLinkTitle: string;
   range: IEditorRange;
+  text: string;
+
 
   locationX: number;
   locationY: number;
@@ -69,6 +72,7 @@ interface IEditorState {
       locationY,
 
       range,
+      text,
       annotation,
     } = selectEditorState(state);
 
@@ -78,6 +82,7 @@ interface IEditorState {
       locationY,
 
       range,
+      text,
       annotation,
     };
   },
@@ -124,6 +129,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
       return {
         annotationId: nextAnnotation.id,
         range: nextProps.range,
+        text: nextProps.text,
         ppCategory: attrs.ppCategory || AnnotationPPCategories.ADDITIONAL_INFO,
         comment: attrs.comment || '',
         annotationLink: attrs.annotationLink || '',
@@ -228,6 +234,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
       attributes: {
         url: window.location.href,
         range: this.props.range,
+        quote: this.props.text,
         ppCategory: this.state.ppCategory,
         comment: this.state.comment,
         annotationLink: this.state.annotationLink,

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -11,13 +11,15 @@ import { hideMenu, setSelectionRange, showEditorAnnotation } from 'store/widgets
 import { Range } from 'xpath-range';
 import { PPScopeClass } from '../../class_consts';
 import ppGA from '../../pp-ga';
+import { SerializedRangeWithText } from '../../utils/annotations';
 
 interface IMenuProps {
   locationX: number;
   locationY: number;
   range: Range.SerializedRange;
+  text: string;
 
-  setSelectionRange: (range: Range.SerializedRange) => void;
+  setSelectionRange: (range: SerializedRangeWithText) => void;
   showEditor: (x: number, y: number) => void;
   hideMenu: () => void;
 }
@@ -33,6 +35,7 @@ interface IMenuProps {
     locationX,
     locationY,
     range: state.textSelector.range,
+    text: state.textSelector.text,
   };
 },
   {
@@ -58,10 +61,11 @@ export default class Menu extends React.Component<Partial<IMenuProps>, {}> {
       locationX,
       locationY,
       range,
+      text,
     } = this.props;
 
     this.props.hideMenu();
-    this.props.setSelectionRange(range);
+    this.props.setSelectionRange({range, text});
     this.props.showEditor(locationX, locationY);
     ppGA.annotationAddFormDisplayed('addingModeMenu');
   }

--- a/src/core/TextSelector.ts
+++ b/src/core/TextSelector.ts
@@ -4,6 +4,7 @@ import _isEqual from 'lodash/isEqual';
 import { PPHighlightClass } from 'class_consts';
 // More on xpath-range here: https://github.com/opengovfoundation/xpath-range
 // Wondering what's inside? See https://github.com/opengovfoundation/xpath-range/blob/master/src/range.coffee#L227
+import { SerializedRangeWithText } from '../utils/annotations';
 
 const TEXTSELECTOR_NS = 'pp-textselector';
 
@@ -28,7 +29,11 @@ function hasClassParents(element, selector: string) {
   return (elAndParents.filter(selector).length !== 0);
 }
 
-export type SelectionCallback = (selection: Range.SerializedRange[], isInsideArticle: boolean, event: any) => void;
+export type SelectionCallback = (
+  selectionRangeWithText: SerializedRangeWithText[],
+  isInsideArticle: boolean,
+  event: any,
+) => void;
 
 export interface TextSelectorOptions {
   onMouseUp?: SelectionCallback;
@@ -42,7 +47,7 @@ export default class TextSelector {
   onMouseUp: SelectionCallback;
   onSelectionChange: SelectionCallback;
   outsideArticleSelector: string;
-  lastRanges: Range.SerializedRange[];
+  lastRanges: SerializedRangeWithText[];
 
   constructor(
     element: Element,
@@ -140,8 +145,10 @@ export default class TextSelector {
   serializeRanges = (ranges: Range.NormalizedRange[]) => {
     const serializedRanges = [];
     for (const range of ranges) {
-      const serializedRange = range.serialize(this.element, `.${PPHighlightClass}`);
-      serializedRanges.push(serializedRange);
+      serializedRanges.push({
+        range: range.serialize(this.element, `.${PPHighlightClass}`),
+        text: range.text(),
+      });
     }
     return serializedRanges;
   }

--- a/src/examples/highlight.ts
+++ b/src/examples/highlight.ts
@@ -2,6 +2,7 @@ import { Range } from 'xpath-range';
 import { Highlighter, TextSelector } from 'core/index';
 
 import 'css/selection.scss';
+import { SerializedRangeWithText } from '../utils/annotations';
 
 /*
  * Example of selection becoming a highlight;
@@ -28,13 +29,13 @@ function initializeCoreHandlers() {
   });
 }
 
-function handleSelect(data: Range.SerializedRange[], event) {
+function handleSelect(data: SerializedRangeWithText[], event) {
   console.log('data: ', data);
   console.log('event: ', event);
   if (data) {
     if (data.length === 1) {
       console.log(data);
-      window.highlighter.draw(1, data[0], { test: 'test' });
+      window.highlighter.draw(1, data[0].range, { test: 'test' });
 
       // setTimeout(() => window.highlighter.undraw(1), 1000);
     } else {

--- a/src/init/documentHandlers.ts
+++ b/src/init/documentHandlers.ts
@@ -11,6 +11,7 @@ import highlights from './highlights';
 import { selectModeForCurrentPage } from '../store/appModes/selectors';
 import { setSelectionRange, showEditorAnnotation } from '../store/widgets/actions';
 import ppGA from 'pp-ga';
+import { SerializedRangeWithText } from '../utils/annotations';
 
 let handlers;
 
@@ -36,19 +37,19 @@ export function deinitializeCoreHandlers() {
 }
 
 function selectionChangeCallback(
-  selection: Range.SerializedRange[],
+  selectionRangeWithText: SerializedRangeWithText[],
   isInsideArticle: boolean,
   event) {
 
   const appModes = selectModeForCurrentPage(store.getState());
   if (appModes.isAnnotationMode) {
-    if (selection.length === 0 || (selection.length === 1 && !isInsideArticle)) {
+    if (selectionRangeWithText.length === 0 || (selectionRangeWithText.length === 1 && !isInsideArticle)) {
       // Propagate to the store only selections fully inside the article (e.g. not belonging to any of PP components)
       // When we need to react also to other, we can easily expand the textSelector reducer; for now it' too eager.
       store.dispatch(makeSelection(null));
       store.dispatch(hideMenu());
-    } else if (selection.length === 1) {
-      store.dispatch(makeSelection(selection[0]));
+    } else if (selectionRangeWithText.length === 1) {
+      store.dispatch(makeSelection(selectionRangeWithText[0]));
       store.dispatch(showMenu(mousePosition(event)));
     } else {
       console.warn('PP: more than one selected range is not supported');

--- a/src/init/highlights.ts
+++ b/src/init/highlights.ts
@@ -41,10 +41,10 @@ function drawHighlights() {
     const annotationsToDraw = annotations.map((annotation) => {
       const { quote, range } = annotation.attributes;
       let locatedRange;
-      if (quote) {
-        locatedRange = uniqueTextToXPathRange(quote, document.body);
-      } else {
+      if (range) {
         locatedRange = range;
+      } else {
+        locatedRange = uniqueTextToXPathRange(quote, document.body);
       }
       if (locatedRange) {
         return {

--- a/src/store/textSelector/actions.ts
+++ b/src/store/textSelector/actions.ts
@@ -1,12 +1,17 @@
 import { Range } from 'xpath-range';
+import { SerializedRangeWithText } from '../../utils/annotations';
 
 export const TEXT_SELECTED = 'TEXT_SELECTED';
 
-export function makeSelection(range: Range.SerializedRange) {
+export function makeSelection(rangeWithText?: SerializedRangeWithText) {
   return {
     type: TEXT_SELECTED,
-    payload: {
-      range,
+    payload: rangeWithText ? {
+      range: rangeWithText.range,
+      text: rangeWithText.text,
+    } : {
+      range: null,
+      text: '',
     },
   };
 }

--- a/src/store/textSelector/reducers.ts
+++ b/src/store/textSelector/reducers.ts
@@ -17,5 +17,6 @@ function textSelectedActionHandler(state, payload) {
   return {
     ...state,
     range: payload.range,
+    text: payload.text,
   };
 }

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -1,4 +1,5 @@
 import { Range } from 'xpath-range';
+import { SerializedRangeWithText } from '../../utils/annotations';
 
 export const EDITOR_ANNOTATION = 'EDITOR_ANNOTATION';
 export const SET_EDITOR_SELECTION_RANGE = 'SET_EDITOR_SELECTION_RANGE';
@@ -22,11 +23,12 @@ export const showEditorAnnotation = (x: number, y: number, id?: string) => {
   };
 };
 
-export const setSelectionRange = (range: Range.SerializedRange) => {
+export const setSelectionRange = (rangeWithText: SerializedRangeWithText) => {
   return {
     type: SET_EDITOR_SELECTION_RANGE,
     payload: {
-      range,
+      range: rangeWithText.range,
+      text: rangeWithText.text,
     },
   };
 };

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -19,18 +19,22 @@ function selectAnnotationForm(annotations, editor) {
   // When the annotation is being created for the first time, range is stored in state.editor.range;
   // If the annotation already exists, it is taken from annotation API model.
   let range;
+  let text;
   let annotation;
   if (annotationId) {
     annotation = annotations.find(x => x.id === annotationId);
     range = annotation.attributes.range;
+    text = annotation.attributes.text;
   } else {
     annotation = null;
     range = editor.range;
+    text = editor.text;
   }
 
   return {
     annotation,
     range,
+    text,
   };
 }
 

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -1,4 +1,3 @@
-
 import rangy from 'rangy';
 import 'rangy/lib/rangy-classapplier';
 import 'rangy/lib/rangy-highlighter';
@@ -30,4 +29,9 @@ export function uniqueTextToXPathRange(text: string, element: Node): Range.Seria
   } else {
     return null;
   }
+}
+
+export interface SerializedRangeWithText {
+  range: Range.SerializedRange;
+  text: string;
 }


### PR DESCRIPTION
Always sending 'quote` when creating annotation resolves part of #175 and brings back the annotation adding function by adjusting to current backend requirements.