### PR TITLE
Annotation data flow modifications + additional location information + docs

### DIFF
--- a/@types/xpath-range/index.d.ts
+++ b/@types/xpath-range/index.d.ts
@@ -8,13 +8,13 @@ declare module 'xpath-range' {
 
     export class BrowserRange {
 
-      constructor(range: any);
-
       commonAncestorContainer: Element;
       startContainer: Text;
       startOffset: number;
       endContainer: Text;
       endOffset: number;
+
+      constructor(range: any);
 
       normalize(): NormalizedRange;
     }
@@ -25,6 +25,7 @@ declare module 'xpath-range' {
       end: Text;
 
       serialize(contextElement: Element, ignoreSelector?: string): SerializedRange;
+
       /*
         contextElement: according to xpath comments: "A root Element from which to anchor the serialisation."
         ignoreSelector: according to xpath comments: "A selector String of elements to ignore. For example
@@ -33,7 +34,11 @@ declare module 'xpath-range' {
        */
 
       text(): string;
+
+      textNodes(): Node[];
+
       normalize(Element): NormalizedRange;
+
       limit(element: Element);
     }
 

--- a/@types/xpath-range/index.d.ts
+++ b/@types/xpath-range/index.d.ts
@@ -28,7 +28,7 @@ declare module 'xpath-range' {
       /*
         contextElement: according to xpath comments: "A root Element from which to anchor the serialisation."
         ignoreSelector: according to xpath comments: "A selector String of elements to ignore. For example
-          elements injected by the annotator". In other words, element no to account for when calculating selection
+          elements injected by the annotator". In other words, element not to account for when calculating selection
           offset (e.g. volatile spans created by other annotations)
        */
 

--- a/README.md
+++ b/README.md
@@ -159,4 +159,6 @@ npm run build
 
 [More notes on building](docs/build.md)
 
+[Annotating DOM](docs/DOM-annotation.md)
+
 [Valuable references](docs/references.md)

--- a/docs/DOM-annotation.md
+++ b/docs/DOM-annotation.md
@@ -1,0 +1,18 @@
+
+### Libraries used
+
+- `xpath-range` (see below for details)
+- parts of [annotator](https://github.com/openannotation/annotator) project (exploiting xpath-range)
+- [rangy](https://github.com/timdown/rangy)
+
+#### why?
+
+`annotator` + `xpath-range` provide a specialised, but a tested and stable annotation solution;
+
+`rangy` is a popular library with a huge API operating on DOM ranges/selections, necessary where xpath-range cannot be used.
+
+#### Notes on xpath-range
+
+We use `xpath-range` in version 0.0.5 since in later versions most of the functionality was removed.
+
+[Here](docs/xpath-range-README-0.0.5.md) is the README provided with that version (hard to find otherwise)

--- a/docs/xpath-range-README-0.0.5.md
+++ b/docs/xpath-range-README-0.0.5.md
@@ -1,0 +1,80 @@
+# xpath-range
+
+[![Build Status](https://travis-ci.org/openannotation/xpath-range.svg?branch=master)](https://travis-ci.org/openannotation/xpath-range)
+
+## Introduction
+
+A (Browser) Range implementation / wrapper, with XPath creation features.
+
+This module implements three Range objects: `BrowserRange`, `SerializedRange`, and `NormalizedRange`.
+
+### BrowserRange
+
+This serves to just provide a wrapper around the DOM Range object with two additional functions: `serialize()` returns an object fit for serialization, and `normalize()` returns a `NormalizedRange` instance after normalizing the range. (Normalization involves moving the start or end of the range based on some rules.)
+
+### NormalizedRange
+
+This object provides different properties than the DOM Range, but encapsulates the same concept. It also adds a few other methods.
+
+The `serialize()` method is actually the serialization as described in `BrowserRange`. The `BrowserRange` `serialize()` method actually calls `normalize()` first to get a `NormalizedRange`. and then calls `serialize()` on that.
+
+Most of serialization is a simple XPath builder with the added detail that a relative root can be passed in.
+
+`NormalizedRange` objects also provide a function to get the text nodes they contain, to get the string of text contained by those text nodes, and to get a real DOM Range object.
+
+It's worth noting that `NormalizedRange#text()` is probably the equivalent of the DOM Range `#toString()` method.
+
+A `limit()` method provides the ability to reduce the range to only the nodes that fall inside the given container.
+
+### SerializedRange
+
+This serves as an OO wrapper around a serializable Range. It contains an XPath expression for each of the DOM Range object's start- and endContainer properties as well a the start and end offsets. Its `normalize()` method first attempts to resolve to XPath to find this range in the document and, having resolved the start- and endContainer nodes, returns a `NormalizedRange.`
+
+## Usage
+
+You can install `xpath-range` by executing `npm intall xpath-range`.
+`xpath-range` is also [browserify](http://browserify.org/)-compatible, so you can simply `require()` it in your code.
+
+Example code to create a serialized, xpath-based description of the region currectly selected by the user:
+
+```
+Range = require("xpath-range").Range;
+
+doMagic = function() {
+  range	= getSelection().getRangeAt(0);
+  bRange = new Range.BrowserRange(range);
+  sRange = bRange.serialize(document.body);
+  console.log(sRange);
+}
+```
+
+Run this through Browserify, and include the resulting JS bundle in an HTML document like this:
+
+```
+<html>
+  <body>
+    <script src="test-run.js"></script>
+    <p>
+      This is a test text.
+    </p>
+  </body>
+</html>
+
+```
+
+After loading the page, and selecting something on the page, you can execute the `doMagic()` function (from the dev console), and you will see the xpath-based, serialized form of your selection. (Which will be pretty simple, given the example document, but hey, it's s start.)
+
+## Development
+
+If you want to contribute/fix something, you should fork this repository, add your contribution, and send a PR.
+Don't forget to add/modify test cases to cover your change.
+
+## Testing
+
+You can run the command-line test suite by executing `npm test`, or you can launch the development environment using `npm start', and then point your browser to http://localhost:4000/test/runner.html
+
+## Maintainers
+
+Originally, this code has been part of the [Annotator project](http://annotatorjs.org/). It has been separated from [it's repository](https://github.com/openannotation/annotator).
+
+Any discussion should happen on the [annotator-dev](https://lists.okfn.org/mailman/listinfo/annotator-dev) mailing list.

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "build": "webpack --mode production --config config/client/prod.config.js",
     "start": "webpack-dev-server --mode development --config config/client/dev.config.js",
-    "start-extension": "webpack --mode development --config config/browser-extension/ext.dev.config.js --watch",
+    "start-extension": "webpack --mode development --env.api=local --config config/browser-extension/ext.dev.config.js --watch",
     "build-dev-extension": "webpack --mode development --config config/browser-extension/ext.dev.config.js",
     "build-extension": "webpack --mode production --env.api=pp --config config/browser-extension/ext.prod.config.js && cd dist && zip -r pp-chrome.zip browser-extension",
     "lint": "tslint --project tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "build": "webpack --mode production --config config/client/prod.config.js",
     "start": "webpack-dev-server --mode development --config config/client/dev.config.js",
-    "start-extension": "webpack --mode development --env.api=local --config config/browser-extension/ext.dev.config.js --watch",
+    "start-extension": "webpack --mode development --config config/browser-extension/ext.dev.config.js --watch",
     "build-dev-extension": "webpack --mode development --config config/browser-extension/ext.dev.config.js",
     "build-extension": "webpack --mode production --env.api=pp --config config/browser-extension/ext.prod.config.js && cd dist && zip -r pp-chrome.zip browser-extension",
     "lint": "tslint --project tsconfig.json",

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -35,7 +35,7 @@ interface IEditorProps {
 
   annotation: AnnotationAPIModel;
   range: IEditorRange;
-  text: string;
+  quote: string;
 
   createOrUpdateAnnotation: (instance: AnnotationAPICreateModel) => Promise<object>;
   hideEditor: () => void;
@@ -48,8 +48,7 @@ interface IEditorState {
   annotationLink: string;
   annotationLinkTitle: string;
   range: IEditorRange;
-  text: string;
-
+  quote: string;
 
   locationX: number;
   locationY: number;
@@ -72,7 +71,7 @@ interface IEditorState {
       locationY,
 
       range,
-      text,
+      quote,
       annotation,
     } = selectEditorState(state);
 
@@ -82,7 +81,7 @@ interface IEditorState {
       locationY,
 
       range,
-      text,
+      quote,
       annotation,
     };
   },
@@ -129,7 +128,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
       return {
         annotationId: nextAnnotation.id,
         range: nextProps.range,
-        text: nextProps.text,
+        quote: nextProps.quote,
         ppCategory: attrs.ppCategory || AnnotationPPCategories.ADDITIONAL_INFO,
         comment: attrs.comment || '',
         annotationLink: attrs.annotationLink || '',
@@ -234,7 +233,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
       attributes: {
         url: window.location.href,
         range: this.props.range,
-        quote: this.props.text,
+        quote: this.props.quote,
         ppCategory: this.state.ppCategory,
         comment: this.state.comment,
         annotationLink: this.state.annotationLink,

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -26,6 +26,7 @@ import * as helpers from './helpers';
 import styles from './Editor.scss';
 import ppGA from 'pp-ga';
 import { AnnotationPPCategories } from '../../api/annotations';
+import { AnnotationLocation } from '../../utils/annotations';
 
 interface IEditorProps {
   appModes: AppModes;
@@ -34,8 +35,7 @@ interface IEditorProps {
   locationY: number;
 
   annotation: AnnotationAPIModel;
-  range: IEditorRange;
-  quote: string;
+  annotationLocation: AnnotationLocation;
 
   createOrUpdateAnnotation: (instance: AnnotationAPICreateModel) => Promise<object>;
   hideEditor: () => void;
@@ -47,8 +47,7 @@ interface IEditorState {
   comment: string;
   annotationLink: string;
   annotationLinkTitle: string;
-  range: IEditorRange;
-  quote: string;
+  annotationLocation: AnnotationLocation;
 
   locationX: number;
   locationY: number;
@@ -70,8 +69,7 @@ interface IEditorState {
       locationX,
       locationY,
 
-      range,
-      quote,
+      annotationLocation,
       annotation,
     } = selectEditorState(state);
 
@@ -80,8 +78,7 @@ interface IEditorState {
       locationX,
       locationY,
 
-      range,
-      quote,
+      annotationLocation,
       annotation,
     };
   },
@@ -120,15 +117,14 @@ class Editor extends React.Component<Partial<IEditorProps>,
     // Note: nextProps.annotation && nextProps.annotation.id === prevState.annotationId will generate updates
     // if only nextProps.annotation is null
     const areAnnotationsEqual = prevState.annotationId === nextAnnotation.id;
-    const areRangesEqual = _isEqual(prevState.range, nextProps.range);
+    const areRangesEqual = _isEqual(prevState.annotationLocation, nextProps.annotationLocation);
     if (areAnnotationsEqual && areRangesEqual) {
       return null;
     } else {
       const attrs: Partial<AnnotationAPIModelAttrs> = nextAnnotation.attributes || {};
       return {
         annotationId: nextAnnotation.id,
-        range: nextProps.range,
-        quote: nextProps.quote,
+        annotationLocation: nextProps.annotationLocation,
         ppCategory: attrs.ppCategory || AnnotationPPCategories.ADDITIONAL_INFO,
         comment: attrs.comment || '',
         annotationLink: attrs.annotationLink || '',
@@ -227,13 +223,20 @@ class Editor extends React.Component<Partial<IEditorProps>,
   }
 
   getAnnotationFromState() {
+    const {
+      range,
+      quote,
+      quoteContext,
+    } = this.props.annotationLocation;
+
     return {
       id: this.props.annotation ? this.props.annotation.id : null,
       type: 'annotations',
       attributes: {
         url: window.location.href,
-        range: this.props.range,
-        quote: this.props.quote,
+        range,
+        quote,
+        quoteContext,
         ppCategory: this.state.ppCategory,
         comment: this.state.comment,
         annotationLink: this.state.annotationLink,
@@ -288,7 +291,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
         mover={this.moverElement}
         onMoved={this.onMoved}
       >
-        <PPCategoryButtonsBar onSetPPCategory={this.handleSetPPCategory} ppCategory={ppCategory} />
+        <PPCategoryButtonsBar onSetPPCategory={this.handleSetPPCategory} ppCategory={ppCategory}/>
         <div
           className={styles.close}
           onClick={this.onCancelClick}
@@ -296,7 +299,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
           <i className="remove icon"/>
         </div>
         <div className={classNames(styles.editorInput)}>
-           <div className={classNames(styles.commentTextareaWrapper)}>
+          <div className={classNames(styles.commentTextareaWrapper)}>
             <textarea
               autoFocus={true}
               name="comment"
@@ -374,7 +377,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
               />
             </div>
           </div>
-          <span className={styles.moverIcon} />
+          <span className={styles.moverIcon}/>
         </div>
       </DraggableWidget>
     );

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -17,7 +17,7 @@ interface IMenuProps {
   locationX: number;
   locationY: number;
   range: XPathRange.SerializedRange;
-  text: string;
+  quote: string;
 
   setSelectionRange: (range: AnnotationLocation) => void;
   showEditor: (x: number, y: number) => void;
@@ -35,7 +35,7 @@ interface IMenuProps {
     locationX,
     locationY,
     range: state.textSelector.range,
-    text: state.textSelector.text,
+    quote: state.textSelector.quote,
   };
 },
   {
@@ -61,11 +61,11 @@ export default class Menu extends React.Component<Partial<IMenuProps>, {}> {
       locationX,
       locationY,
       range,
-      text,
+      quote,
     } = this.props;
 
     this.props.hideMenu();
-    this.props.setSelectionRange({range, text});
+    this.props.setSelectionRange({ range, quote });
     this.props.showEditor(locationX, locationY);
     ppGA.annotationAddFormDisplayed('addingModeMenu');
   }

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -16,8 +16,7 @@ import { AnnotationLocation } from '../../utils/annotations';
 interface IMenuProps {
   locationX: number;
   locationY: number;
-  range: XPathRange.SerializedRange;
-  quote: string;
+  annotationLocation: AnnotationLocation;
 
   setSelectionRange: (range: AnnotationLocation) => void;
   showEditor: (x: number, y: number) => void;
@@ -29,13 +28,13 @@ interface IMenuProps {
   const {
     locationX,
     locationY,
+    annotationLocation,
   } = selectMenuState(state);
 
   return {
     locationX,
     locationY,
-    range: state.textSelector.range,
-    quote: state.textSelector.quote,
+    annotationLocation,
   };
 },
   {
@@ -60,12 +59,11 @@ export default class Menu extends React.Component<Partial<IMenuProps>, {}> {
     const {
       locationX,
       locationY,
-      range,
-      quote,
+      annotationLocation,
     } = this.props;
 
     this.props.hideMenu();
-    this.props.setSelectionRange({ range, quote });
+    this.props.setSelectionRange(annotationLocation);
     this.props.showEditor(locationX, locationY);
     ppGA.annotationAddFormDisplayed('addingModeMenu');
   }

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -11,7 +11,7 @@ import { hideMenu, setSelectionRange, showEditorAnnotation } from 'store/widgets
 import { Range } from 'xpath-range';
 import { PPScopeClass } from '../../class_consts';
 import ppGA from '../../pp-ga';
-import { SerializedRangeWithText } from '../../utils/annotations';
+import { AnnotationLocation } from '../../utils/annotations';
 
 interface IMenuProps {
   locationX: number;
@@ -19,7 +19,7 @@ interface IMenuProps {
   range: Range.SerializedRange;
   text: string;
 
-  setSelectionRange: (range: SerializedRangeWithText) => void;
+  setSelectionRange: (range: AnnotationLocation) => void;
   showEditor: (x: number, y: number) => void;
   hideMenu: () => void;
 }

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -8,7 +8,7 @@ import Widget from 'components/widget';
 
 import styles from './Menu.scss';
 import { hideMenu, setSelectionRange, showEditorAnnotation } from 'store/widgets/actions';
-import { Range } from 'xpath-range';
+import { Range as XPathRange } from 'xpath-range';
 import { PPScopeClass } from '../../class_consts';
 import ppGA from '../../pp-ga';
 import { AnnotationLocation } from '../../utils/annotations';
@@ -16,7 +16,7 @@ import { AnnotationLocation } from '../../utils/annotations';
 interface IMenuProps {
   locationX: number;
   locationY: number;
-  range: Range.SerializedRange;
+  range: XPathRange.SerializedRange;
   text: string;
 
   setSelectionRange: (range: AnnotationLocation) => void;

--- a/src/core/Highlighter.ts
+++ b/src/core/Highlighter.ts
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import { PPHighlightClass } from 'class_consts';
-import { Range } from 'xpath-range';
+import { Range as XPathRange } from 'xpath-range';
 
 /**
  * highlightRange wraps the DOM Nodes within the provided range with a highlight
@@ -36,16 +36,16 @@ function highlightRange(normedRange, cssClass) {
 }
 
 /**
- * reanchorRange will attempt to normalize a range, swallowing Range.RangeErrors
+ * reanchorRange will attempt to normalize a range, swallowing XPathRange.RangeErrors
  * for those ranges which are not reanchorable in the current document.
  */
-function reanchorRange(range, rootElement): Range.NormalizedRange {
-  const sniffedRange = Range.sniff(range);
+function reanchorRange(range, rootElement): XPathRange.NormalizedRange {
+  const sniffedRange = XPathRange.sniff(range);
   if (sniffedRange) {
     try {
       return sniffedRange.normalize(rootElement);
     } catch (e) {
-      if (!(e instanceof Range.RangeError)) {
+      if (!(e instanceof XPathRange.RangeError)) {
         // Oh Javascript, why you so crap? This will lose the traceback.
         throw(e);
       }

--- a/src/core/TextSelector.ts
+++ b/src/core/TextSelector.ts
@@ -1,4 +1,4 @@
-import { Range } from 'xpath-range';
+import { Range as XPathRange } from 'xpath-range';
 import $ from 'jquery';
 import _isEqual from 'lodash/isEqual';
 import { PPHighlightClass } from 'class_consts';
@@ -29,7 +29,7 @@ function hasClassParents(element, selector: string) {
 }
 
 export type SelectionCallback = (
-  selectionRanges: Range.NormalizedRange[],
+  selectionRanges: XPathRange.NormalizedRange[],
   isInsideArticle: boolean,
   event: any,
 ) => void;
@@ -46,7 +46,7 @@ export default class TextSelector {
   onMouseUp: SelectionCallback;
   onSelectionChange: SelectionCallback;
   outsideArticleSelector: string;
-  lastSelectedRanges: Range.SerializedRange[];
+  lastSelectedRanges: XPathRange.SerializedRange[];
 
   constructor(
     // Element outside which selections will be ignored
@@ -104,7 +104,7 @@ export default class TextSelector {
        TODO we could try to remove the dependency on `Range` (xpath-range) library, but that
        would require writing our own tool for this kind of logic
        */
-      const browserRange = new Range.BrowserRange(r);
+      const browserRange = new XPathRange.BrowserRange(r);
       const normedRange = browserRange.normalize().limit(this.element);
       /*
        If the new range falls fully outside our this.element, we should

--- a/src/core/TextSelector.ts
+++ b/src/core/TextSelector.ts
@@ -4,25 +4,24 @@ import _isEqual from 'lodash/isEqual';
 import { PPHighlightClass } from 'class_consts';
 // More on xpath-range here: https://github.com/opengovfoundation/xpath-range
 // Wondering what's inside? See https://github.com/opengovfoundation/xpath-range/blob/master/src/range.coffee#L227
-import { AnnotationLocation } from '../utils/annotations';
-
-const TEXTSELECTOR_NS = 'pp-textselector';
+import { annotationRootNode } from './index';
 
 /**
  * TextSelector monitors a document (or a specific element) for text selections
- * and can notify another object of a selection event
+ * and can call selection events.
  *
- * It is PP's adaptation of annotator's TextSelectors
+ * It is free from application business logic and provides very primary functionality
+ * TextSelector currently:
+ * - calls text selection events (selection made / selection changed)
+ * - returns a range normalized over different browsers (as a xpath-range NormalizedRange)
+ * - may provide some other DOM related functionality such as filtering out selection made outside provided DOM nodes
+ * It handles all kinds of selection (also multi-range selection).
+ * Although we further assume that no more than one range can be selected for an annotation, there is no reason to
+ * stop supporting it at such an early stage. If we ever stumble across multi-range selections
+ * we will discover it from TextSelectors output (while no exceptions will be thrown)
  */
 
-/*
- * IMPORTANT NOTE on SELECTION RANGES
- * We leave annotator's TextSelector more or less as it is;
- * It can handle all kinds of selection (also multi-range selection). Although our application further assumes that
- * no more than one range can be selected for an annotation, there is no reason to stop supporting it at such an early
- * stage. If we ever stumble across multi-range selections it will be clear based on TextSelectors output
- * (rather than exceptions).
- */
+const TEXTSELECTOR_EVENT_NS = 'pp-textselector';
 
 function hasClassParents(element, selector: string) {
   const elAndParents = $(element).parents().addBack();
@@ -30,7 +29,7 @@ function hasClassParents(element, selector: string) {
 }
 
 export type SelectionCallback = (
-  annotationLocations: AnnotationLocation[],
+  selectionRanges: Range.NormalizedRange[],
   isInsideArticle: boolean,
   event: any,
 ) => void;
@@ -47,13 +46,15 @@ export default class TextSelector {
   onMouseUp: SelectionCallback;
   onSelectionChange: SelectionCallback;
   outsideArticleSelector: string;
-  lastAnnotationLocations: AnnotationLocation[];
+  lastSelectedRanges: Range.SerializedRange[];
 
   constructor(
+    // Element outside which selections will be ignored
     element: Element,
     options: TextSelectorOptions,
   ) {
     /*
+     * options:
      * onMouseUp - called on every mouseUp event, passing current selection;
      * onSelectionChange - called only when the selection has changed
      */
@@ -63,12 +64,12 @@ export default class TextSelector {
     this.onSelectionChange = options.onSelectionChange;
     // an OR selector to match any of the classes external to the article
     this.outsideArticleSelector = (options.outsideArticleClasses || []).map(cls => `.${cls}`).join(', ');
-    this.lastAnnotationLocations = null;
+    this.lastSelectedRanges = null;
 
     if (this.element.ownerDocument) {
       this.document = this.element.ownerDocument;
 
-      $(this.document.body).on(`mouseup.${TEXTSELECTOR_NS}`, this.checkForEndSelection);
+      $(this.document.body).on(`mouseup.${TEXTSELECTOR_EVENT_NS}`, this.checkForEndSelection);
     } else {
       console.warn(`You created an instance of the TextSelector on an element
        that doesn't have an ownerDocument. This won't work! Please ensure the element is added
@@ -78,7 +79,7 @@ export default class TextSelector {
 
   destroy = () => {
     if (this.document) {
-      $(this.document.body).off(`.${TEXTSELECTOR_NS}`);
+      $(this.document.body).off(`.${TEXTSELECTOR_EVENT_NS}`);
     }
   }
 
@@ -137,22 +138,6 @@ export default class TextSelector {
     return ranges;
   }
 
-  currentSerializedSelection = () => {
-    const selectedRanges = this.captureDocumentSelection();
-    return this.serializeRanges(selectedRanges);
-  }
-
-  serializeRanges = (ranges: Range.NormalizedRange[]) => {
-    const serializedRanges = [];
-    for (const range of ranges) {
-      serializedRanges.push({
-        range: range.serialize(this.element, `.${PPHighlightClass}`),
-        text: range.text(),
-      });
-    }
-    return serializedRanges;
-  }
-
   currentSingleSelectionCenter = () => {
     /*
      * We assume only a single selection is made
@@ -179,6 +164,7 @@ export default class TextSelector {
    *
    * Returns nothing.
    */
+
   checkForEndSelection = (event) => {
 
     // Get the currently selected ranges.
@@ -197,17 +183,19 @@ export default class TextSelector {
       }
     }
 
-    const serializedRanges = this.serializeRanges(selectedRanges);
-
     if (this.onSelectionChange) {
-      if (!_isEqual(serializedRanges, this.lastAnnotationLocations)) {
-        this.onSelectionChange(serializedRanges, isInsideArticle, event);
+      // Serialize ranges so they can be compared for equality
+      const serializedRanges = selectedRanges.map(range =>
+        range.serialize(annotationRootNode()),
+      );
+      if (!_isEqual(serializedRanges, this.lastSelectedRanges)) {
+        this.onSelectionChange(selectedRanges, isInsideArticle, event);
       }
+      this.lastSelectedRanges = serializedRanges;
     }
     if (this.onMouseUp) {
-      this.onMouseUp(serializedRanges, isInsideArticle, event);
+      this.onMouseUp(selectedRanges, isInsideArticle, event);
     }
-    this.lastAnnotationLocations = serializedRanges;
   }
 
   /*

--- a/src/core/TextSelector.ts
+++ b/src/core/TextSelector.ts
@@ -4,7 +4,7 @@ import _isEqual from 'lodash/isEqual';
 import { PPHighlightClass } from 'class_consts';
 // More on xpath-range here: https://github.com/opengovfoundation/xpath-range
 // Wondering what's inside? See https://github.com/opengovfoundation/xpath-range/blob/master/src/range.coffee#L227
-import { SerializedRangeWithText } from '../utils/annotations';
+import { AnnotationLocation } from '../utils/annotations';
 
 const TEXTSELECTOR_NS = 'pp-textselector';
 
@@ -30,7 +30,7 @@ function hasClassParents(element, selector: string) {
 }
 
 export type SelectionCallback = (
-  selectionRangeWithText: SerializedRangeWithText[],
+  annotationLocations: AnnotationLocation[],
   isInsideArticle: boolean,
   event: any,
 ) => void;
@@ -47,7 +47,7 @@ export default class TextSelector {
   onMouseUp: SelectionCallback;
   onSelectionChange: SelectionCallback;
   outsideArticleSelector: string;
-  lastRanges: SerializedRangeWithText[];
+  lastAnnotationLocations: AnnotationLocation[];
 
   constructor(
     element: Element,
@@ -63,7 +63,7 @@ export default class TextSelector {
     this.onSelectionChange = options.onSelectionChange;
     // an OR selector to match any of the classes external to the article
     this.outsideArticleSelector = (options.outsideArticleClasses || []).map(cls => `.${cls}`).join(', ');
-    this.lastRanges = null;
+    this.lastAnnotationLocations = null;
 
     if (this.element.ownerDocument) {
       this.document = this.element.ownerDocument;
@@ -200,14 +200,14 @@ export default class TextSelector {
     const serializedRanges = this.serializeRanges(selectedRanges);
 
     if (this.onSelectionChange) {
-      if (!_isEqual(serializedRanges, this.lastRanges)) {
+      if (!_isEqual(serializedRanges, this.lastAnnotationLocations)) {
         this.onSelectionChange(serializedRanges, isInsideArticle, event);
       }
     }
     if (this.onMouseUp) {
       this.onMouseUp(serializedRanges, isInsideArticle, event);
     }
-    this.lastRanges = serializedRanges;
+    this.lastAnnotationLocations = serializedRanges;
   }
 
   /*

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,2 +1,8 @@
 export { default as Highlighter } from './Highlighter';
 export { default as TextSelector } from './TextSelector';
+
+// The node within which annotations are made
+// It's lazy so operations on DOM can be done here if needed
+export function annotationRootNode() {
+  return document.body;
+}

--- a/src/examples/highlight.ts
+++ b/src/examples/highlight.ts
@@ -2,7 +2,7 @@ import { Range } from 'xpath-range';
 import { Highlighter, TextSelector } from 'core/index';
 
 import 'css/selection.scss';
-import { SerializedRangeWithText } from '../utils/annotations';
+import { AnnotationLocation } from '../utils/annotations';
 
 /*
  * Example of selection becoming a highlight;
@@ -29,7 +29,7 @@ function initializeCoreHandlers() {
   });
 }
 
-function handleSelect(data: SerializedRangeWithText[], event) {
+function handleSelect(data: AnnotationLocation[], event) {
   console.log('data: ', data);
   console.log('event: ', event);
   if (data) {

--- a/src/examples/highlight.ts
+++ b/src/examples/highlight.ts
@@ -1,4 +1,4 @@
-import { Range } from 'xpath-range';
+import { Range as XPathRange } from 'xpath-range';
 import { Highlighter, TextSelector } from 'core/index';
 
 import 'css/selection.scss';
@@ -29,7 +29,7 @@ function initializeCoreHandlers() {
   });
 }
 
-function handleSelect(data: Range.NormalizedRange[], event) {
+function handleSelect(data: XPathRange.NormalizedRange[], event) {
   console.log('data: ', data);
   console.log('event: ', event);
   if (data) {

--- a/src/examples/highlight.ts
+++ b/src/examples/highlight.ts
@@ -29,13 +29,13 @@ function initializeCoreHandlers() {
   });
 }
 
-function handleSelect(data: AnnotationLocation[], event) {
+function handleSelect(data: Range.NormalizedRange[], event) {
   console.log('data: ', data);
   console.log('event: ', event);
   if (data) {
     if (data.length === 1) {
       console.log(data);
-      window.highlighter.draw(1, data[0].range, { test: 'test' });
+      window.highlighter.draw(1, data[0].serialize(document.body), { test: 'test' });
 
       // setTimeout(() => window.highlighter.undraw(1), 1000);
     } else {

--- a/src/init/documentHandlers.ts
+++ b/src/init/documentHandlers.ts
@@ -12,6 +12,7 @@ import { selectModeForCurrentPage } from '../store/appModes/selectors';
 import { setSelectionRange, showEditorAnnotation } from '../store/widgets/actions';
 import ppGA from 'pp-ga';
 import { AnnotationLocation, fullAnnotationLocation } from '../utils/annotations';
+import processAnnotations from './processAnnotations';
 
 let handlers;
 
@@ -28,6 +29,7 @@ export function initializeDocumentHandlers() {
   };
 
   highlights.init(highlighter);
+  processAnnotations.init();
   chrome.runtime.onMessage.addListener(contextMenuAnnotateCallback);
 }
 

--- a/src/init/documentHandlers.ts
+++ b/src/init/documentHandlers.ts
@@ -1,4 +1,4 @@
-import { Range } from 'xpath-range';
+import { Range as XPathRange } from 'xpath-range';
 
 import { mousePosition } from 'common/dom';
 import store from 'store';
@@ -37,7 +37,7 @@ export function deinitializeCoreHandlers() {
 }
 
 function selectionChangeCallback(
-  selectedRanges: Range.NormalizedRange[],
+  selectedRanges: XPathRange.NormalizedRange[],
   isInsideArticle: boolean,
   event) {
 

--- a/src/init/documentHandlers.ts
+++ b/src/init/documentHandlers.ts
@@ -4,20 +4,20 @@ import { mousePosition } from 'common/dom';
 import store from 'store';
 import { makeSelection, showMenu } from 'store/actions';
 
-import { Highlighter, TextSelector } from '../core/index';
+import { annotationRootNode, Highlighter, TextSelector } from '../core/index';
 import { hideMenu } from 'store/widgets/actions';
 import { outsideArticleClasses } from 'class_consts';
 import highlights from './highlights';
 import { selectModeForCurrentPage } from '../store/appModes/selectors';
 import { setSelectionRange, showEditorAnnotation } from '../store/widgets/actions';
 import ppGA from 'pp-ga';
-import { AnnotationLocation } from '../utils/annotations';
+import { AnnotationLocation, fullAnnotationLocation } from '../utils/annotations';
 
 let handlers;
 
 export function initializeDocumentHandlers() {
-  const highlighter = new Highlighter(document.body);
-  const selector = new TextSelector(document.body, {
+  const highlighter = new Highlighter(annotationRootNode());
+  const selector = new TextSelector(annotationRootNode(), {
     onSelectionChange: selectionChangeCallback,
     outsideArticleClasses,
   });
@@ -37,19 +37,19 @@ export function deinitializeCoreHandlers() {
 }
 
 function selectionChangeCallback(
-  annotationLocations: AnnotationLocation[],
+  selectedRanges: Range.NormalizedRange[],
   isInsideArticle: boolean,
   event) {
 
   const appModes = selectModeForCurrentPage(store.getState());
   if (appModes.isAnnotationMode) {
-    if (annotationLocations.length === 0 || (annotationLocations.length === 1 && !isInsideArticle)) {
+    if (selectedRanges.length === 0 || (selectedRanges.length === 1 && !isInsideArticle)) {
       // Propagate to the store only selections fully inside the article (e.g. not belonging to any of PP components)
       // When we need to react also to other, we can easily expand the textSelector reducer; for now it' too eager.
       store.dispatch(makeSelection(null));
       store.dispatch(hideMenu());
-    } else if (annotationLocations.length === 1) {
-      store.dispatch(makeSelection(annotationLocations[0]));
+    } else if (selectedRanges.length === 1) {
+      store.dispatch(makeSelection(fullAnnotationLocation(selectedRanges[0])));
       store.dispatch(showMenu(mousePosition(event)));
     } else {
       console.warn('PP: more than one selected range is not supported');
@@ -64,9 +64,10 @@ function contextMenuAnnotateCallback(request, sender) {
      * Reason: checking ContextMenu API selection for being insideArticle is possible, but uncomfortable,
      * as context menu actions are handled in the separate background script.
      */
-    const selection = handlers.selector.currentSerializedSelection();
+    const selection = handlers.selector.captureDocumentSelection();
     if (selection.length === 1) {
-      store.dispatch(setSelectionRange(selection[0]));
+      const annotationLocation = fullAnnotationLocation(selection[0]);
+      store.dispatch(setSelectionRange(annotationLocation));
       const selectionCenter = handlers.selector.currentSingleSelectionCenter();
       store.dispatch(showEditorAnnotation(selectionCenter.x, selectionCenter.y));
       ppGA.annotationAddFormDisplayed('rightMouseContextMenu');

--- a/src/init/documentHandlers.ts
+++ b/src/init/documentHandlers.ts
@@ -11,7 +11,7 @@ import highlights from './highlights';
 import { selectModeForCurrentPage } from '../store/appModes/selectors';
 import { setSelectionRange, showEditorAnnotation } from '../store/widgets/actions';
 import ppGA from 'pp-ga';
-import { SerializedRangeWithText } from '../utils/annotations';
+import { AnnotationLocation } from '../utils/annotations';
 
 let handlers;
 
@@ -37,19 +37,19 @@ export function deinitializeCoreHandlers() {
 }
 
 function selectionChangeCallback(
-  selectionRangeWithText: SerializedRangeWithText[],
+  annotationLocations: AnnotationLocation[],
   isInsideArticle: boolean,
   event) {
 
   const appModes = selectModeForCurrentPage(store.getState());
   if (appModes.isAnnotationMode) {
-    if (selectionRangeWithText.length === 0 || (selectionRangeWithText.length === 1 && !isInsideArticle)) {
+    if (annotationLocations.length === 0 || (annotationLocations.length === 1 && !isInsideArticle)) {
       // Propagate to the store only selections fully inside the article (e.g. not belonging to any of PP components)
       // When we need to react also to other, we can easily expand the textSelector reducer; for now it' too eager.
       store.dispatch(makeSelection(null));
       store.dispatch(hideMenu());
-    } else if (selectionRangeWithText.length === 1) {
-      store.dispatch(makeSelection(selectionRangeWithText[0]));
+    } else if (annotationLocations.length === 1) {
+      store.dispatch(makeSelection(annotationLocations[0]));
       store.dispatch(showMenu(mousePosition(event)));
     } else {
       console.warn('PP: more than one selected range is not supported');

--- a/src/init/documentHandlers.ts
+++ b/src/init/documentHandlers.ts
@@ -42,6 +42,7 @@ function selectionChangeCallback(
   event) {
 
   const appModes = selectModeForCurrentPage(store.getState());
+  // Show the "add annotation" menu if in the annotation mode
   if (appModes.isAnnotationMode) {
     if (selectedRanges.length === 0 || (selectedRanges.length === 1 && !isInsideArticle)) {
       // Propagate to the store only selections fully inside the article (e.g. not belonging to any of PP components)

--- a/src/init/highlights.ts
+++ b/src/init/highlights.ts
@@ -5,9 +5,9 @@ import Highlighter from 'core/Highlighter';
 import { setMouseOverViewer } from '../store/widgets/actions';
 import { selectModeForCurrentPage } from '../store/appModes/selectors';
 import _difference from 'lodash/difference';
+import _isEqual from 'lodash/isEqual';
 import { selectViewerState } from '../store/widgets/selectors';
-import { selectAnnotations } from '../store/api/selectors';
-import { uniqueTextToXPathRange } from '../utils/annotations';
+import { selectAnnotation } from '../store/api/selectors';
 
 let instance;
 
@@ -32,37 +32,26 @@ function deinit() {
 
 function drawHighlights() {
   const arePageHighlightsDisabled = selectModeForCurrentPage(store.getState()).arePageHighlightsDisabled;
-  const annotations = selectAnnotations(store.getState());
+  const locatedAnnotationsIds = store.getState().annotations.located.map(annotation => annotation.annotationId);
   if (arePageHighlightsDisabled && !instance.arePageHighlightsDisabled) {
     instance.highlighter.undrawAll();
   } else if (!arePageHighlightsDisabled &&
-    (annotations !== instance.annotations || arePageHighlightsDisabled !== instance.arePageHighlightsDisabled)
+    (!_isEqual(locatedAnnotationsIds, instance.locatedAnnotationsIds)
+      || arePageHighlightsDisabled !== instance.arePageHighlightsDisabled
+    )
   ) {
-    const annotationsToDraw = annotations.map((annotation) => {
-      const { quote, range } = annotation.attributes;
-      let locatedRange;
-      if (range) {
-        locatedRange = range;
-      } else {
-        locatedRange = uniqueTextToXPathRange(quote);
-      }
-      if (locatedRange) {
-        return {
-          id: annotation.id,
-          range: locatedRange,
-          annotationData: annotation,
-        };
-      } else {
-        return null;
-      }
-    }).filter(annotation => annotation);
-
-    instance.highlighter.drawAll(annotationsToDraw);
+    // located annotations have changed, so redraw them
+    instance.highlighter.drawAll(store.getState().annotations.located.map(({ annotationId, range }) => {
+      return {
+        id: annotationId,
+        range,
+        annotationData: selectAnnotation(store.getState(), annotationId),
+      };
+    }));
   }
 
-  // save for later, to check if updates are needed
-  instance.annotations = annotations;
   instance.arePageHighlightsDisabled = arePageHighlightsDisabled;
+  instance.locatedAnnotationsIds = locatedAnnotationsIds;
 }
 
 function handleHighlightMouseLeave(e, annotations) {

--- a/src/init/highlights.ts
+++ b/src/init/highlights.ts
@@ -44,7 +44,7 @@ function drawHighlights() {
       if (range) {
         locatedRange = range;
       } else {
-        locatedRange = uniqueTextToXPathRange(quote, document.body);
+        locatedRange = uniqueTextToXPathRange(quote);
       }
       if (locatedRange) {
         return {

--- a/src/init/processAnnotations.ts
+++ b/src/init/processAnnotations.ts
@@ -1,0 +1,62 @@
+import store from 'store';
+import { mousePosition } from 'common/dom';
+import _isEqual from 'lodash/isEqual';
+import { selectAnnotations } from '../store/api/selectors';
+import { findUniqueTextInDOMAsRange } from '../utils/annotations';
+import { locateAnnotations } from '../store/annotations/actions';
+import { LocatedAnnotation } from '../store/annotations/types';
+import { AnnotationAPIModel } from '../api/annotations';
+
+let instance;
+
+function init() {
+  // subscribe to store changes and return unsubscribe fn
+  const unsubscribe = store.subscribe(processAnnotations);
+
+  // store objects required for later operations
+  instance = {
+    unsubscribe,
+  };
+}
+
+function deinit() {
+  instance.unsubscribe();
+}
+
+function processAnnotations() {
+  const annotations: AnnotationAPIModel[] = selectAnnotations(store.getState());
+  const annotationIds: string[] = annotations.map(annotation => annotation.id);
+
+  // if annotation items have changed, locate them within the DOM
+  if (!_isEqual(annotationIds, instance.annotationIds)) {
+    const locatedAnnotations: LocatedAnnotation[] = [];
+    const unlocatedAnnotations: string[] = [];
+    for (const annotation of annotations) {
+      const { quote, range } = annotation.attributes;
+      let locatedRange;
+      if (range) {
+        locatedRange = range;
+      } else {
+        locatedRange = findUniqueTextInDOMAsRange(quote);
+      }
+      if (locatedRange) {
+        locatedAnnotations.push({
+          annotationId: annotation.id,
+          range: locatedRange,
+        });
+      } else {
+        unlocatedAnnotations.push(annotation.id);
+      }
+    }
+    // save for later, to check if updates are needed
+    // Do i before dispatching, or we'll into inifite dispatch loop!
+    instance.annotationIds = annotationIds;
+    store.dispatch(locateAnnotations(locatedAnnotations, unlocatedAnnotations));
+  }
+
+}
+
+export default {
+  init,
+  deinit,
+};

--- a/src/store/annotations/actions.ts
+++ b/src/store/annotations/actions.ts
@@ -1,0 +1,13 @@
+import { LocatedAnnotation } from './types';
+
+export const LOCATE_ANNOTATIONS = 'LOCATE_ANNOTATIONS';
+
+export function locateAnnotations(locatedAnnotations: LocatedAnnotation[], unlocatedAnnotations: string[]) {
+  return {
+    type: LOCATE_ANNOTATIONS,
+    payload: {
+      located: locatedAnnotations,
+      unlocated: unlocatedAnnotations,
+    },
+  };
+}

--- a/src/store/annotations/reducers.ts
+++ b/src/store/annotations/reducers.ts
@@ -1,0 +1,19 @@
+import { LOCATE_ANNOTATIONS } from './actions';
+import { AnnotationsState, LocatedAnnotation } from './types';
+
+const initialState: AnnotationsState = {
+  located: [],
+  unlocated: [],
+};
+
+export default function annotations(state = initialState, action): AnnotationsState {
+  switch (action.type) {
+    case LOCATE_ANNOTATIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/store/annotations/types.ts
+++ b/src/store/annotations/types.ts
@@ -1,0 +1,11 @@
+import { Range as XPathRange } from 'xpath-range';
+
+export interface AnnotationsState {
+  located: LocatedAnnotation[];
+  unlocated: string[];
+}
+
+export interface LocatedAnnotation {
+  annotationId: string;
+  range: XPathRange.SerializedRange;
+}

--- a/src/store/api/selectors.ts
+++ b/src/store/api/selectors.ts
@@ -1,6 +1,5 @@
 import { ITabState } from '../reducer';
 
-
 export function selectAnnotations(state: ITabState) {
   return state.api.annotations.data;
 }

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -6,12 +6,15 @@ import appModes from './appModes/reducers';
 import textSelector from './textSelector/reducers';
 import { AnnotationAPIModel } from 'api/annotations';
 import { AnnotationUpvoteAPIModel } from 'api/annotation-upvotes';
+import { AnnotationsState } from './annotations/types';
+import annotations from './annotations/reducers';
 
 export interface ITabState {
   api: {
     annotations: { data: AnnotationAPIModel[] };
     annotationUpvotes: { data: AnnotationUpvoteAPIModel[] };
   };
+  annotations: AnnotationsState;
   appModes: AppModes;
   widgets: WidgetReducer;
   textSelector: any;
@@ -29,6 +32,7 @@ export const apiInitializedFields = {
 
 export default combineReducers<ITabState>({
   api,
+  annotations,
   appModes,
   widgets,
   textSelector,

--- a/src/store/textSelector/actions.ts
+++ b/src/store/textSelector/actions.ts
@@ -1,14 +1,14 @@
 import { Range } from 'xpath-range';
-import { SerializedRangeWithText } from '../../utils/annotations';
+import { AnnotationLocation } from '../../utils/annotations';
 
 export const TEXT_SELECTED = 'TEXT_SELECTED';
 
-export function makeSelection(rangeWithText?: SerializedRangeWithText) {
+export function makeSelection(annotationLocation?: AnnotationLocation) {
   return {
     type: TEXT_SELECTED,
-    payload: rangeWithText ? {
-      range: rangeWithText.range,
-      text: rangeWithText.text,
+    payload: annotationLocation ? {
+      range: annotationLocation.range,
+      text: annotationLocation.text,
     } : {
       range: null,
       text: '',

--- a/src/store/textSelector/actions.ts
+++ b/src/store/textSelector/actions.ts
@@ -1,4 +1,4 @@
-import { Range } from 'xpath-range';
+import { Range as XPathRange } from 'xpath-range';
 import { AnnotationLocation } from '../../utils/annotations';
 
 export const TEXT_SELECTED = 'TEXT_SELECTED';

--- a/src/store/textSelector/actions.ts
+++ b/src/store/textSelector/actions.ts
@@ -8,10 +8,10 @@ export function makeSelection(annotationLocation?: AnnotationLocation) {
     type: TEXT_SELECTED,
     payload: annotationLocation ? {
       range: annotationLocation.range,
-      text: annotationLocation.text,
+      quote: annotationLocation.quote,
     } : {
       range: null,
-      text: '',
+      quote: '',
     },
   };
 }

--- a/src/store/textSelector/actions.ts
+++ b/src/store/textSelector/actions.ts
@@ -7,11 +7,11 @@ export function makeSelection(annotationLocation?: AnnotationLocation) {
   return {
     type: TEXT_SELECTED,
     payload: annotationLocation ? {
-      range: annotationLocation.range,
-      quote: annotationLocation.quote,
+      ...annotationLocation,
     } : {
       range: null,
       quote: '',
+      quoteContext: '',
     },
   };
 }

--- a/src/store/textSelector/reducers.ts
+++ b/src/store/textSelector/reducers.ts
@@ -16,7 +16,6 @@ export default function textSelector(state = initialState, action) {
 function textSelectedActionHandler(state, payload) {
   return {
     ...state,
-    range: payload.range,
-    quote: payload.quote,
+    ...payload,
   };
 }

--- a/src/store/textSelector/reducers.ts
+++ b/src/store/textSelector/reducers.ts
@@ -17,6 +17,6 @@ function textSelectedActionHandler(state, payload) {
   return {
     ...state,
     range: payload.range,
-    text: payload.text,
+    quote: payload.quote,
   };
 }

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -1,4 +1,4 @@
-import { Range } from 'xpath-range';
+import { Range as XPathRange } from 'xpath-range';
 import { AnnotationLocation } from '../../utils/annotations';
 
 export const EDITOR_ANNOTATION = 'EDITOR_ANNOTATION';

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -1,5 +1,5 @@
 import { Range } from 'xpath-range';
-import { SerializedRangeWithText } from '../../utils/annotations';
+import { AnnotationLocation } from '../../utils/annotations';
 
 export const EDITOR_ANNOTATION = 'EDITOR_ANNOTATION';
 export const SET_EDITOR_SELECTION_RANGE = 'SET_EDITOR_SELECTION_RANGE';
@@ -23,12 +23,12 @@ export const showEditorAnnotation = (x: number, y: number, id?: string) => {
   };
 };
 
-export const setSelectionRange = (rangeWithText: SerializedRangeWithText) => {
+export const setSelectionRange = (annotationLocation: AnnotationLocation) => {
   return {
     type: SET_EDITOR_SELECTION_RANGE,
     payload: {
-      range: rangeWithText.range,
-      text: rangeWithText.text,
+      range: annotationLocation.range,
+      text: annotationLocation.text,
     },
   };
 };

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -27,8 +27,7 @@ export const setSelectionRange = (annotationLocation: AnnotationLocation) => {
   return {
     type: SET_EDITOR_SELECTION_RANGE,
     payload: {
-      range: annotationLocation.range,
-      quote: annotationLocation.quote,
+      annotationLocation,
     },
   };
 };

--- a/src/store/widgets/actions.ts
+++ b/src/store/widgets/actions.ts
@@ -28,7 +28,7 @@ export const setSelectionRange = (annotationLocation: AnnotationLocation) => {
     type: SET_EDITOR_SELECTION_RANGE,
     payload: {
       range: annotationLocation.range,
-      text: annotationLocation.text,
+      quote: annotationLocation.quote,
     },
   };
 };

--- a/src/store/widgets/reducers.ts
+++ b/src/store/widgets/reducers.ts
@@ -11,6 +11,7 @@ import { AnnotationResourceType } from 'api/annotations';
 import { combineReducers } from 'redux';
 import { MODIFY_APP_MODES } from '../appModes/actions';
 import { isAnnotationMode } from 'store/appModes/selectors';
+import { AnnotationLocation } from '../../utils/annotations';
 
 export interface IWidgetState {
   visible: boolean;
@@ -38,7 +39,7 @@ export interface IEditorRange {
 
 export interface IEditorState extends IWidgetState {
   annotationId: string;
-  range: IEditorRange;
+  annotationLocation: AnnotationLocation;
 }
 
 export interface WidgetReducer {

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -9,32 +9,37 @@ function selectWidgetState({ location, visible }) {
   };
 }
 
-export const selectMenuState = createSelector<ITabState, any, any>(
+export const selectMenuState = createSelector<ITabState, any, any, any>(
   state => state.widgets.menu,
-  selectWidgetState,
+    state => state.textSelector,
+  (menu, textSelector) => ({
+    ...selectWidgetState(menu),
+    annotationLocation: { ...textSelector },
+  }),
 );
 
 function selectAnnotationForm(annotations, editor) {
   const annotationId = editor.annotationId;
-  // When the annotation is being created for the first time, range is stored in state.editor.range;
+  // When the annotation is being created for the first time, annotation location is stored in
+  // state.editor.annotationLocation;
   // If the annotation already exists, it is taken from annotation API model.
   let annotation;
-  let range;
-  let quote;
+  let annotationLocation;
   if (annotationId) {
     annotation = annotations.find(x => x.id === annotationId);
-    range = annotation.attributes.range;
-    quote = annotation.attributes.quote;
+    annotationLocation = {
+      range: annotation.attributes.range,
+      quote: annotation.attributes.quote,
+      quoteContext: annotation.attributes.quoteContext,
+    };
   } else {
     annotation = null;
-    range = editor.range;
-    quote = editor.quote;
+    annotationLocation = { ...editor.annotationLocation };
   }
 
   return {
     annotation,
-    range,
-    quote,
+    annotationLocation,
   };
 }
 

--- a/src/store/widgets/selectors.ts
+++ b/src/store/widgets/selectors.ts
@@ -18,23 +18,23 @@ function selectAnnotationForm(annotations, editor) {
   const annotationId = editor.annotationId;
   // When the annotation is being created for the first time, range is stored in state.editor.range;
   // If the annotation already exists, it is taken from annotation API model.
-  let range;
-  let text;
   let annotation;
+  let range;
+  let quote;
   if (annotationId) {
     annotation = annotations.find(x => x.id === annotationId);
     range = annotation.attributes.range;
-    text = annotation.attributes.text;
+    quote = annotation.attributes.quote;
   } else {
     annotation = null;
     range = editor.range;
-    text = editor.text;
+    quote = editor.quote;
   }
 
   return {
     annotation,
     range,
-    text,
+    quote,
   };
 }
 

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -8,7 +8,7 @@ import { escapeRegExp } from 'tslint/lib/utils';
 import { PPHighlightClass } from '../class_consts';
 import { annotationRootNode } from '../core';
 
-export function uniqueTextToXPathRange(text: string, element: Node): XPathRange.SerializedRange {
+export function uniqueTextToXPathRange(text: string): XPathRange.SerializedRange {
   const searchScopeRange = rangy.createRange();
   searchScopeRange.selectNodeContents(document.body);
   const options = {
@@ -26,8 +26,7 @@ export function uniqueTextToXPathRange(text: string, element: Node): XPathRange.
   // Assume there is only one text like this on the page and return the first one
   if (range.findText(new RegExp(searchRegexp), options)) {
     const browserRange = new XPathRange.BrowserRange(range);
-    const normedRange = browserRange.normalize().limit(document.body);
-    return normedRange.serialize(element);
+    const normedRange = browserRange.normalize().limit(annotationRootNode()).serialize(annotationRootNode());
   } else {
     return null;
   }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -8,7 +8,7 @@ import { escapeRegExp } from 'tslint/lib/utils';
 import { PPHighlightClass } from '../class_consts';
 import { annotationRootNode } from '../core';
 
-export function uniqueTextToXPathRange(quote: string): XPathRange.SerializedRange {
+export function findUniqueTextInDOMAsRange(quote: string): XPathRange.SerializedRange {
   const searchScopeRange = rangy.createRange();
   searchScopeRange.selectNodeContents(document.body);
   const options = {

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -25,8 +25,7 @@ export function uniqueTextToXPathRange(quote: string): XPathRange.SerializedRang
 
   // Assume there is only one text like this on the page and return the first one
   if (range.findText(new RegExp(searchRegexp), options)) {
-    const browserRange = new XPathRange.BrowserRange(range);
-    const normedRange = browserRange.normalize().limit(annotationRootNode()).serialize(annotationRootNode());
+    return new XPathRange.BrowserRange(range).normalize().limit(annotationRootNode()).serialize(annotationRootNode());
   } else {
     return null;
   }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -5,6 +5,8 @@ import 'rangy/lib/rangy-textrange';
 import 'rangy/lib/rangy-serializer';
 import { Range } from 'xpath-range';
 import { escapeRegExp } from 'tslint/lib/utils';
+import { PPHighlightClass } from '../class_consts';
+import { annotationRootNode } from '../core';
 
 export function uniqueTextToXPathRange(text: string, element: Node): Range.SerializedRange {
   const searchScopeRange = rangy.createRange();
@@ -34,4 +36,12 @@ export function uniqueTextToXPathRange(text: string, element: Node): Range.Seria
 export interface AnnotationLocation {
   range: Range.SerializedRange;
   text: string;
+}
+
+export function fullAnnotationLocation(range: Range.NormalizedRange): AnnotationLocation {
+  const serializedRanges = [];
+  return {
+      range: range.serialize(annotationRootNode(), `.${PPHighlightClass}`),
+      text: range.text(),
+  };
 }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -31,7 +31,7 @@ export function uniqueTextToXPathRange(text: string, element: Node): Range.Seria
   }
 }
 
-export interface SerializedRangeWithText {
+export interface AnnotationLocation {
   range: Range.SerializedRange;
   text: string;
 }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -3,12 +3,12 @@ import 'rangy/lib/rangy-classapplier';
 import 'rangy/lib/rangy-highlighter';
 import 'rangy/lib/rangy-textrange';
 import 'rangy/lib/rangy-serializer';
-import { Range } from 'xpath-range';
+import { Range as XPathRange } from 'xpath-range';
 import { escapeRegExp } from 'tslint/lib/utils';
 import { PPHighlightClass } from '../class_consts';
 import { annotationRootNode } from '../core';
 
-export function uniqueTextToXPathRange(text: string, element: Node): Range.SerializedRange {
+export function uniqueTextToXPathRange(text: string, element: Node): XPathRange.SerializedRange {
   const searchScopeRange = rangy.createRange();
   searchScopeRange.selectNodeContents(document.body);
   const options = {
@@ -25,7 +25,7 @@ export function uniqueTextToXPathRange(text: string, element: Node): Range.Seria
 
   // Assume there is only one text like this on the page and return the first one
   if (range.findText(new RegExp(searchRegexp), options)) {
-    const browserRange = new Range.BrowserRange(range);
+    const browserRange = new XPathRange.BrowserRange(range);
     const normedRange = browserRange.normalize().limit(document.body);
     return normedRange.serialize(element);
   } else {
@@ -34,11 +34,11 @@ export function uniqueTextToXPathRange(text: string, element: Node): Range.Seria
 }
 
 export interface AnnotationLocation {
-  range: Range.SerializedRange;
+  range: XPathRange.SerializedRange;
   text: string;
 }
 
-export function fullAnnotationLocation(range: Range.NormalizedRange): AnnotationLocation {
+export function fullAnnotationLocation(range: XPathRange.NormalizedRange): AnnotationLocation {
   const serializedRanges = [];
   return {
       range: range.serialize(annotationRootNode(), `.${PPHighlightClass}`),

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -32,15 +32,31 @@ export function uniqueTextToXPathRange(quote: string): XPathRange.SerializedRang
   }
 }
 
+export function XPathNormalizedRangeToRangyRange(xPathRange: XPathRange.NormalizedRange) {
+  const rangyRange = rangy.createRange();
+  const textNodes = xPathRange.textNodes();
+  rangyRange.setStartBefore(textNodes[0]);
+  rangyRange.setEndAfter(textNodes[textNodes.length - 1]);
+  return rangyRange;
+}
+
 export interface AnnotationLocation {
   range: XPathRange.SerializedRange;
   quote: string;
+  quoteContext: string;
 }
 
-export function fullAnnotationLocation(range: XPathRange.NormalizedRange): AnnotationLocation {
-  const serializedRanges = [];
+export function fullAnnotationLocation(normalizedRange: XPathRange.NormalizedRange): AnnotationLocation {
+  const contextWidth = 100;
+  // rangy.getSelection().setSingleRange(x);
+  const rangyRange = XPathNormalizedRangeToRangyRange(normalizedRange);
+  const quote = rangyRange.text();
+  rangyRange.moveStart('character', -contextWidth);
+  rangyRange.moveEnd('character', contextWidth);
+  const quoteContext = rangyRange.text();
   return {
-      range: range.serialize(annotationRootNode(), `.${PPHighlightClass}`),
-      quote: range.text(),
+      range: normalizedRange.serialize(annotationRootNode(), `.${PPHighlightClass}`),
+      quote,
+      quoteContext,
   };
 }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -8,7 +8,7 @@ import { escapeRegExp } from 'tslint/lib/utils';
 import { PPHighlightClass } from '../class_consts';
 import { annotationRootNode } from '../core';
 
-export function uniqueTextToXPathRange(text: string): XPathRange.SerializedRange {
+export function uniqueTextToXPathRange(quote: string): XPathRange.SerializedRange {
   const searchScopeRange = rangy.createRange();
   searchScopeRange.selectNodeContents(document.body);
   const options = {
@@ -21,7 +21,7 @@ export function uniqueTextToXPathRange(text: string): XPathRange.SerializedRange
   // 1. Escape the characters (e.g. '.', '(', ')') having special meaning in regex
   // 2. Replace spaces with \s+ for more robustness
   // todo consider removing some other characters not essential to the sentence content
-  const searchRegexp = escapeRegExp(text.trim()).replace(/\s/, '\\s+');
+  const searchRegexp = escapeRegExp(quote.trim()).replace(/\s/, '\\s+');
 
   // Assume there is only one text like this on the page and return the first one
   if (range.findText(new RegExp(searchRegexp), options)) {
@@ -34,13 +34,13 @@ export function uniqueTextToXPathRange(text: string): XPathRange.SerializedRange
 
 export interface AnnotationLocation {
   range: XPathRange.SerializedRange;
-  text: string;
+  quote: string;
 }
 
 export function fullAnnotationLocation(range: XPathRange.NormalizedRange): AnnotationLocation {
   const serializedRanges = [];
   return {
       range: range.serialize(annotationRootNode(), `.${PPHighlightClass}`),
-      text: range.text(),
+      quote: range.text(),
   };
 }


### PR DESCRIPTION
Resolves #175 
Resolves #183 

- TextSelector uses only pure `xpath-range` ranges data and is no longer involved in any application logic
- `AnnotationLocation` -- a new explicit grouping of location-related data saved and received with an annotation 
- intermediate explicit annotation location step between data loading and attaching to DOM -- all annotations are explicitly sorted into those that could be located and those that could not.
- Basic information on the DOM annotation-related libraries used in the application
- additional related refactors

This PR should be followed by directory refactor in the source root ( #199 )