### PR TITLE
Fix too strict annotation link validation.

### DIFF
--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,5 +1,5 @@
 // Url without protocol, not very strict validation
-const urlRegex = new RegExp(/^(https?:\/\/)?[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,24}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?$/gi);
+const urlRegex = new RegExp(/^(https?:\/\/)?[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,24}\b(\/[-a-zA-Z0-9@:%_\+.,~#?&//=]*)?$/gi);
 
 export function extractHostname(url) {
   let hostname;


### PR DESCRIPTION
The annotation link can now contain commas after the domain name.

Resolves #162 