### PR TITLE
Add crucial information in HTTP headers: site URL and CSRF token + context menu fix

### DIFF
--- a/config/browser-extension/ext.base.config.js
+++ b/config/browser-extension/ext.base.config.js
@@ -6,7 +6,7 @@ const CreateFileWebpack = require('create-file-webpack');
 const common = require('../base.config');
 const manifestSettings = require('./manifest');
 
-const manifest = merge(manifestSettings.base, {
+const manifest = (env, argv) => merge(manifestSettings.base(env, argv), {
   content_scripts: [{
     ...manifestSettings.contentScriptSettings,
     js: [

--- a/config/browser-extension/ext.dev.config.js
+++ b/config/browser-extension/ext.dev.config.js
@@ -11,30 +11,34 @@ const devPlugins = require('../dev.plugins');
 const KEY = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtxq8nV/aj5t9OCS5BaRfNNVdEYFqSYCfgSRmXzizAGCoIfro6bewIL3tFP4aIkreQHg4/09Xiv6TSJ7ZiFnuVat5iYGC3w1h+z9fzj/i0lyASilp0N7watpAGLh+msGzr59J/lGR7G0Nt3Ixy82RBlLmU5gjR9eHueOMNaUe1m4I74BSPG6GboUmUpidaqAbSV3lgYFppWHDjCQ5rqIkue1JLAsRBwiV+3DeGJs3JN+TfLduEgDzMcNuCkFdym1L+9qJKQI6t56ElkHMse3aToSTrG0flPedfCpPgEcGKfkgDxO11de7hKrRcbX4wmQzACvBm1YzzrLRR7yIRBhFEQIDAQAB';
 const APP_ID = 'lkdlhhnnkbhhnocdodbeikfboeckpaih';
 
-const manifest = merge(common.manifest, {
-  key: KEY,
-});
+const manifest =
 
-module.exports = (env, argv) => merge(common.config(env, argv), {
-  output: {
-    publicPath: `chrome-extension://${APP_ID}/`,
-  },
-  plugins: [
-    // Generate manifest.json
-    new CreateFileWebpack({
-      path: common.EXT_DIR,
-      fileName: 'manifest.json',
-      content: JSON.stringify(manifest, null, 2),
-    }),
-    new ChromeExtensionReloader({
-      port: 9090, // Which port use to create the server
-      reloadPage: true, // Force the reload of the page also
-      entries: { //The entries used for the content/background scripts
-        contentScript: ['main', 'main_global_styles', 'popup'], //Use the entry names, not the file name or the path
-        background: 'background'
-      }
-    }),
-    ...devPlugins,
-  ]
-});
+module.exports = (env, argv) => {
+  const manifest = merge(common.manifest(env, argv), {
+    key: KEY,
+  });
+
+  return merge(common.config(env, argv), {
+    output: {
+      publicPath: `chrome-extension://${APP_ID}/`,
+    },
+    plugins: [
+      // Generate manifest.json
+      new CreateFileWebpack({
+        path: common.EXT_DIR,
+        fileName: 'manifest.json',
+        content: JSON.stringify(manifest, null, 2),
+      }),
+      new ChromeExtensionReloader({
+        port: 9090, // Which port use to create the server
+        reloadPage: true, // Force the reload of the page also
+        entries: { //The entries used for the content/background scripts
+          contentScript: ['main', 'main_global_styles', 'popup'], //Use the entry names, not the file name or the path
+          background: 'background'
+        }
+      }),
+      ...devPlugins,
+    ]
+  })
+};
 

--- a/config/browser-extension/ext.prod.config.js
+++ b/config/browser-extension/ext.prod.config.js
@@ -12,17 +12,23 @@ const manifest = merge(common.manifest, {
   key: KEY,
 });
 
-module.exports = (env, argv) => merge(common.config(env, argv), {
-  output: {
-    publicPath: `chrome-extension://${APP_ID}/`,
-  },
-  plugins: [
-    // Generate manifest.json
-    new CreateFileWebpack({
-      path: common.EXT_DIR,
-      fileName: 'manifest.json',
-      content: JSON.stringify(manifest, null, 2),
-    }),
-  ]
-});
+module.exports = (env, argv) => {
+  const manifest = merge(common.manifest(env, argv), {
+    key: KEY,
+  });
+
+  return merge(common.config(env, argv), {
+    output: {
+      publicPath: `chrome-extension://${APP_ID}/`,
+    },
+    plugins: [
+      // Generate manifest.json
+      new CreateFileWebpack({
+        path: common.EXT_DIR,
+        fileName: 'manifest.json',
+        content: JSON.stringify(manifest, null, 2),
+      }),
+    ]
+  });
+};
 

--- a/config/browser-extension/manifest.js
+++ b/config/browser-extension/manifest.js
@@ -3,8 +3,9 @@
 // Contains only the most universal information;
 // For more details see values appended in browser-extension/*.config.js file
 const packageConf = require('../../package');
+const appSettings = require('../app-settings').appSettings;
 
-const base = {
+const base = (env, argv) => ({
   manifest_version: 2,
   name: 'Przypis Powszechny',
   description: '',
@@ -15,9 +16,12 @@ const base = {
     'storage',
     'activeTab',
     'contextMenus',
+    'cookies',
+    // API URL must be included so we can read cookies for this host
+    appSettings(env, argv).API_URL,
   ],
-  content_security_policy: "script-src 'self' 'unsafe-eval' https://www.google-analytics.com; object-src 'self'",
-  browser_action: {
+    content_security_policy: "script-src 'self' 'unsafe-eval' https://www.google-analytics.com; object-src 'self'",
+    browser_action: {
     default_title: 'Przypis Powszechny - wersja testowa'
   },
   web_accessible_resources: [
@@ -26,7 +30,7 @@ const base = {
     'node_modules/*',
     'fonts/*'
   ]
-};
+});
 
 const contentScriptSettings = {
   matches: ['<all_urls>'],

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -26,6 +26,12 @@ function onInstalled(details: InstalledDetails) {
       // ignore 'chrome_update' and 'shared_module_update'
       break;
   }
+
+  chrome.contextMenus.create({
+    title: 'Dodaj przypis',
+    contexts: ['selection'],
+    onclick: onContextMenuAnnotate,
+  });
 }
 
 function returnExtensionCookie(request, sender, sendResponse) {
@@ -44,12 +50,6 @@ function returnExtensionCookie(request, sender, sendResponse) {
 }
 
 ppGA.init();
-
-chrome.contextMenus.create({
-  title: 'Dodaj przypis',
-  contexts: ['selection'],
-  onclick: onContextMenuAnnotate,
-});
 
 chrome.runtime.onInstalled.addListener(onInstalled);
 chrome.runtime.setUninstallURL(PP_SETTINGS.SITE_URL + '/extension-uninstalled/');

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -28,6 +28,21 @@ function onInstalled(details: InstalledDetails) {
   }
 }
 
+function returnExtensionCookie(request, sender, sendResponse) {
+  if (request.action === 'GET_COOKIE') {
+    chrome.cookies.get({
+      url: PP_SETTINGS.API_URL,
+      name: request.name,
+    }, (cookie: chrome.cookies.Cookie) => {
+      sendResponse({
+        name: cookie.name,
+        value: cookie.value,
+      });
+    });
+  }
+  return true;
+}
+
 ppGA.init();
 
 chrome.contextMenus.create({
@@ -39,3 +54,4 @@ chrome.contextMenus.create({
 chrome.runtime.onInstalled.addListener(onInstalled);
 chrome.runtime.setUninstallURL(PP_SETTINGS.SITE_URL + '/extension-uninstalled/');
 chrome.runtime.onMessage.addListener(ppGA.sendEventFromMessage);
+chrome.runtime.onMessage.addListener(returnExtensionCookie);

--- a/src/common/pp-ga/core.ts
+++ b/src/common/pp-ga/core.ts
@@ -26,8 +26,6 @@ export function init() {
   ga('set', 'appVersion', packageConf.version);
 
   sendInitPing();
-  const cookies = cookie.parse(document.cookie);
-  console.log(cookies);
 }
 
 interface InitPingResponseData {

--- a/src/common/pp-ga/core.ts
+++ b/src/common/pp-ga/core.ts
@@ -26,6 +26,8 @@ export function init() {
   ga('set', 'appVersion', packageConf.version);
 
   sendInitPing();
+  const cookies = cookie.parse(document.cookie);
+  console.log(cookies);
 }
 
 interface InitPingResponseData {

--- a/src/content-scripts/init-API.ts
+++ b/src/content-scripts/init-API.ts
@@ -2,11 +2,39 @@ import store from './store/store';
 import axios from 'axios';
 import { setAxiosConfig } from 'redux-json-api';
 
-export function configureAPIRequests() {
+function getExtensionCookie(name: string) {
+  // Read special per-extension cookie
+  // available not for the host domain (unlike traditional website cookies) but for this particular extension client
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage({ action: 'GET_COOKIE', name }, (response) => {
+      if (response) {
+        resolve(response.value);
+      } else {
+        resolve(null);
+      }
+    });
+  });
+}
 
-  // add header consumed by '/annotations' endpoint for URL filtering
+export function configureAPIRequests() {
+  /*
+   * Crucial configuration:
+   * 1. Add PP-SITE-URL header (used to protect browsing history as opposed to ordinary GET parameters)
+   * consumed by API in annotation list endpoint
+   * 2. ADD CSRF token header for all state-changing requests
+   */
   axios.interceptors.request.use((config) => {
     config.headers['PP-SITE-URL'] = window.location.href;
+
+    if (['POST', 'PATCH', 'PUT'].indexOf(config.method) >= 0) {
+      return getExtensionCookie('csrftoken').then((csrfToken) => {
+        if (!csrfToken) {
+          return Promise.reject(`CSRF token is not available when initiating a ${config.method} request!`);
+        }
+        config.headers['X-CSRFToken'] = csrfToken;
+        return Promise.resolve(config);
+      });
+    }
     return config;
   });
 
@@ -15,5 +43,4 @@ export function configureAPIRequests() {
     baseURL: PP_SETTINGS.API_URL,
     withCredentials: true,
   }));
-
 }

--- a/src/content-scripts/init-API.ts
+++ b/src/content-scripts/init-API.ts
@@ -1,0 +1,19 @@
+import store from './store/store';
+import axios from 'axios';
+import { setAxiosConfig } from 'redux-json-api';
+
+export function configureAPIRequests() {
+
+  // add header consumed by '/annotations' endpoint for URL filtering
+  axios.interceptors.request.use((config) => {
+    config.headers['PP-SITE-URL'] = window.location.href;
+    return config;
+  });
+
+  // settings for redux-json-api
+  store.dispatch(setAxiosConfig({
+    baseURL: PP_SETTINGS.API_URL,
+    withCredentials: true,
+  }));
+
+}

--- a/src/content-scripts/init-data.ts
+++ b/src/content-scripts/init-data.ts
@@ -1,13 +1,12 @@
 import * as chromeKeys from 'common/chrome-storage/keys';
 import { changeAppModes } from './store/appModes/actions';
 import store from './store';
-
+import axios from 'axios';
 import chromeStorage from 'common/chrome-storage';
 import { readEndpoint } from 'redux-json-api';
 
 export function loadFromAPI() {
-  // This is our root request that needs to have part of the url (path) hardcoded
-  store.dispatch(readEndpoint('/annotations?url=' + window.location.href));
+  store.dispatch(readEndpoint('/annotations'));
 }
 
 export function loadFromChromeStorage() {

--- a/src/content-scripts/main.tsx
+++ b/src/content-scripts/main.tsx
@@ -20,6 +20,8 @@ import highlightManager from './modules/highlight-manager';
 import annotationLocator from './modules/annotation-locator';
 import annotationEventHandlers from './handlers/annotation-event-handlers';
 import appComponent from './modules/app-component';
+import store from './store/store';
+import { configureAPIRequests } from './init-API';
 
 moment.locale('pl');
 
@@ -42,6 +44,7 @@ console.log('Przypis script working!');
  * we commit changes to browser storage and recalculate state.appMode on storage change.
  */
 
+
 const isBrowser = typeof window !== 'undefined';
 if (isBrowser) {
   window.addEventListener('load', () => {
@@ -57,6 +60,9 @@ if (isBrowser) {
     highlightManager.init();
     annotationLocator.init();
     appComponent.init();
+
+    // API settings
+    configureAPIRequests();
 
     // Optimization: load data from storage first, so annotations are not drawn before we know current application modes
     // (disabled extension mode and disabled page mode will erase them)

--- a/src/content-scripts/store/store.ts
+++ b/src/content-scripts/store/store.ts
@@ -3,7 +3,6 @@ import thunk from 'redux-thunk';
 import rootReducer, { apiInitializedFields, ITabState } from './reducer';
 import promise from 'redux-promise';
 import { createLogger } from 'redux-logger';
-import { setAxiosConfig } from 'redux-json-api';
 
 // TS override
 declare global {
@@ -26,10 +25,5 @@ const store: Store<ITabState> = createStore(
     applyMiddleware(...middlewares),
   ),
 );
-
-store.dispatch(setAxiosConfig({
-  baseURL: PP_SETTINGS.API_URL,
-  withCredentials: true,
-}));
 
 export default store;


### PR DESCRIPTION
Resolves #176 
Resolves #218 

CSRF token is available via chrome extension background page `chrome.cookies` API, since traditional `document.cookie` won't return the cookies set by HTTP requests since the API domain and background-page/content script domain differ.

The already complicated webpack configuration got temporarily slightly more complicated and simplifying it should be a priority.

After merging, merge https://github.com/PrzypisPowszechny/pp/pull/70