### PR TITLE
Selenium env fixes

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -43,10 +43,17 @@ function returnExtensionCookie(request, sender, sendResponse) {
       url: PPSettings.API_URL,
       name: request.name,
     }, (cookie: chrome.cookies.Cookie) => {
-      sendResponse({
-        name: cookie.name,
-        value: cookie.value,
-      });
+      if (cookie) {
+        sendResponse({
+          name: cookie.name,
+          value: cookie.value,
+        });
+      } else {
+        sendResponse({
+          name: request.name,
+          value: null,
+        });
+      }
     });
   }
   return true;

--- a/src/content-scripts/init-API.ts
+++ b/src/content-scripts/init-API.ts
@@ -26,7 +26,7 @@ export function configureAPIRequests() {
   axios.interceptors.request.use((config) => {
     config.headers['PP-SITE-URL'] = window.location.href;
 
-    if (['OPTIONS', 'GET', 'HEAD'].indexOf(config.method) === -1) {
+    if (['options', 'get', 'head'].indexOf(config.method) === -1) {
       return getExtensionCookie('csrftoken').then((csrfToken) => {
         if (!csrfToken) {
           return Promise.reject(`CSRF token is not available when initiating a ${config.method} request!`);


### PR DESCRIPTION
Two bug fixes

- `csrftoken` was expected for any request method (not only for modification requests) and `csrftoken` cookie was expected while making any request
- cookie request from content script to background script caused crash when running extension in chrome with selenium; as a consequence, content script axios fetches blocked waiting synchronously for response from the background script
