### PR TITLE
Menu and toast enhancements

### DIFF
--- a/src/content-scripts/components/AnnotationModeWidget/AnnotationModeWidget.tsx
+++ b/src/content-scripts/components/AnnotationModeWidget/AnnotationModeWidget.tsx
@@ -7,19 +7,23 @@ import { PPScopeClass } from 'content-scripts/settings';
 import { turnOffAnnotationMode } from 'common/chrome-storage';
 import { AppModes } from 'content-scripts/store/appModes/types';
 import ppGA from 'common/pp-ga';
+import { hideMenu } from '../../store/widgets/actions';
 
 export interface IAnnotationModeWidgetProps {
   appModes: AppModes;
+  hideMenu: () => void;
 }
 
 @connect(
   state => ({
     appModes: state.appModes,
   }),
+  { hideMenu },
 )
 export default class AnnotationModeWidget extends React.Component<Partial<IAnnotationModeWidgetProps>, {}> {
 
   handleCancelClick = (e: any) => {
+    this.props.hideMenu();
     turnOffAnnotationMode(this.props.appModes, window.location.href);
     ppGA.annotationAddingModeCancelled();
   }

--- a/src/content-scripts/components/AnnotationRequestForm/AnnotationRequestForm.tsx
+++ b/src/content-scripts/components/AnnotationRequestForm/AnnotationRequestForm.tsx
@@ -12,10 +12,11 @@ import { Icon } from 'react-icons-kit';
 import { ic_live_help } from 'react-icons-kit/md/ic_live_help';
 import { changeNotification } from '../../store/widgets/actions';
 import * as helpers from './helpers';
+import { ToastType } from '../elements/Toast/Toast';
 
 export interface AnnotationRequestFormProps {
   appModes: AppModes;
-  changeNotification: (visible: boolean, message?: string) => void;
+  changeNotification: (visible: boolean, message?: string, type?: ToastType) => void;
 }
 
 interface AnnotationRequestFormState extends AnnotationRequestFormData {
@@ -96,6 +97,9 @@ export default class AnnotationRequestForm extends React.Component<Partial<Annot
       }).then((response) => {
         this.props.changeNotification(true, 'Twoja prośba o przypis została wysłana');
         turnOffRequestMode(this.props.appModes, window.location.href);
+      }).catch((error) => {
+        console.log(error);
+        this.props.changeNotification(true, 'Błąd! Nie udało się wysłać prośby', ToastType.failure);
       });
     }
   }

--- a/src/content-scripts/components/editor/Editor.tsx
+++ b/src/content-scripts/components/editor/Editor.tsx
@@ -5,17 +5,12 @@ import classNames from 'classnames';
 import { Popup } from 'semantic-ui-react';
 import _isEqual from 'lodash/isEqual';
 
-import {
-  AnnotationAPIModel,
-  AnnotationAPICreateModel,
-  AnnotationAPIModelAttrs,
-} from 'common/api/annotations';
+import { AnnotationAPICreateModel, AnnotationAPIModel, AnnotationAPIModelAttrs, } from 'common/api/annotations';
 import { turnOffAnnotationMode } from 'common/chrome-storage';
 import { PPScopeClass } from 'content-scripts/settings';
 import { hideEditor } from 'content-scripts/store/actions';
 import { AppModes } from 'content-scripts/store/appModes/types';
 import { selectEditorState } from 'content-scripts/store/selectors';
-import { IEditorRange } from 'content-scripts/store/widgets/reducers';
 
 import { DraggableWidget } from 'content-scripts/components/widget';
 
@@ -34,6 +29,7 @@ import { priceTag } from 'react-icons-kit/icomoon/priceTag';
 import { ic_close } from 'react-icons-kit/md/ic_close';
 import { changeNotification } from '../../store/widgets/actions';
 import { bindActionCreators } from 'redux';
+import { ToastType } from '../elements/Toast/Toast';
 
 interface IEditorProps {
   appModes: AppModes;
@@ -46,7 +42,7 @@ interface IEditorProps {
 
   createOrUpdateAnnotation: (instance: AnnotationAPICreateModel) => Promise<object>;
   hideEditor: () => void;
-  changeNotification: (visible: boolean, message?: string) => void;
+  changeNotification: (visible: boolean, message?: string, type?: ToastType) => void;
 }
 
 interface IEditorState {
@@ -271,15 +267,15 @@ class Editor extends React.Component<Partial<IEditorProps>,
         if (isNewInstance) {
           turnOffAnnotationMode(this.props.appModes, window.location.href);
           ppGA.annotationAdded(instance.id, attributes.ppCategory, !attributes.comment, attributes.annotationLink);
-          this.props.changeNotification(true, 'Dodałeś/aś przypis');
+          this.props.changeNotification(true, 'Dodałeś/aś przypis', ToastType.success);
         } else {
           ppGA.annotationEdited(instance.id, attributes.ppCategory, !attributes.comment, attributes.annotationLink);
-          this.props.changeNotification(true, 'Edytowałeś/aś przypis');
+          this.props.changeNotification(true, 'Edytowałeś/aś przypis', ToastType.success);
         }
       }).catch((errors) => {
         this.setState({ isCreating: false });
         console.log(errors);
-        // TODO: show error toast here
+        this.props.changeNotification(true, 'Błąd! Nie udało się zapisać przypisu', ToastType.failure);
       });
     }
   }

--- a/src/content-scripts/components/editor/Editor.tsx
+++ b/src/content-scripts/components/editor/Editor.tsx
@@ -32,6 +32,8 @@ import { Icon } from 'react-icons-kit';
 import { link } from 'react-icons-kit/icomoon/link';
 import { priceTag } from 'react-icons-kit/icomoon/priceTag';
 import { ic_close } from 'react-icons-kit/md/ic_close';
+import { changeNotification } from '../../store/widgets/actions';
+import { bindActionCreators } from 'redux';
 
 interface IEditorProps {
   appModes: AppModes;
@@ -44,6 +46,7 @@ interface IEditorProps {
 
   createOrUpdateAnnotation: (instance: AnnotationAPICreateModel) => Promise<object>;
   hideEditor: () => void;
+  changeNotification: (visible: boolean, message?: string) => void;
 }
 
 interface IEditorState {
@@ -88,7 +91,11 @@ interface IEditorState {
     };
   },
   dispatch => ({
-    hideEditor: () => dispatch(hideEditor()),
+    ...bindActionCreators({
+      hideEditor,
+      changeNotification,
+    },
+    dispatch),
     createOrUpdateAnnotation: (instance: AnnotationAPICreateModel) => {
       if (instance.id) {
         return dispatch(updateResource(instance));
@@ -264,8 +271,10 @@ class Editor extends React.Component<Partial<IEditorProps>,
         if (isNewInstance) {
           turnOffAnnotationMode(this.props.appModes, window.location.href);
           ppGA.annotationAdded(instance.id, attributes.ppCategory, !attributes.comment, attributes.annotationLink);
+          this.props.changeNotification(true, 'Dodałeś/aś przypis');
         } else {
           ppGA.annotationEdited(instance.id, attributes.ppCategory, !attributes.comment, attributes.annotationLink);
+          this.props.changeNotification(true, 'Edytowałeś/aś przypis');
         }
       }).catch((errors) => {
         this.setState({ isCreating: false });
@@ -303,7 +312,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
             className={styles.close}
             onClick={this.onCancelClick}
           >
-            <Icon icon={ic_close} size={18} />
+            <Icon icon={ic_close} size={18}/>
           </div>
           <div className={classNames(styles.editorInput)}>
             <div className={classNames(styles.commentTextareaWrapper)}>
@@ -334,7 +343,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
             <Popup
               className={classNames(PPScopeClass, styles.tooltip, 'small-padding')}
               hideOnScroll={true}
-              trigger={<Icon className={styles.inputIcon} icon={link} size={15} />}
+              trigger={<Icon className={styles.inputIcon} icon={link} size={15}/>}
               flowing={true}
               hoverable={true}
               position="top left"
@@ -360,7 +369,7 @@ class Editor extends React.Component<Partial<IEditorProps>,
             <Popup
               className={classNames(PPScopeClass, styles.tooltip, 'small-padding')}
               hideOnScroll={true}
-              trigger={<Icon className={styles.inputIcon} icon={priceTag} size={15} />}
+              trigger={<Icon className={styles.inputIcon} icon={priceTag} size={15}/>}
               flowing={true}
               hoverable={true}
               position="top left"
@@ -378,14 +387,15 @@ class Editor extends React.Component<Partial<IEditorProps>,
             <button className={classNames(styles.submitButton, styles.cancel)} onClick={this.onCancelClick}>
               {' '}Anuluj{' '}
             </button>
-            <button className={classNames(styles.submitButton, styles.save, this.saveButtonClass())} onClick={this.onSaveClick}>
+            <button className={classNames(styles.submitButton, styles.save, this.saveButtonClass())}
+                    onClick={this.onSaveClick}>
               {' '}Zapisz{' '}
             </button>
             {noCommentModalOpen &&
             <NoCommentModal
               onCloseCommentModal={this.handleCloseCommentModal}
               onModalSaveClick={this.handleModalSaveClick}
-          />}
+            />}
           </div>
         </div>
       </DraggableWidget>

--- a/src/content-scripts/components/elements/Toast/Toast.scss
+++ b/src/content-scripts/components/elements/Toast/Toast.scss
@@ -16,10 +16,18 @@ $toast-width: 255px;
   color: white;
   width: $toast-width;
   background-color: #778ca3;
-  border-left: 5px solid #2ecc71;
   display: flex;
   transition: 0.5s ease;
+
+  &.success {
+    border-left: 5px solid #2ecc71;
+  }
+
+  &.failure {
+    border-left: 5px solid #cc3e32;
+  }
 }
+
 
 .hidden {
   transform: translate($toast-width, 0);

--- a/src/content-scripts/components/elements/Toast/Toast.tsx
+++ b/src/content-scripts/components/elements/Toast/Toast.tsx
@@ -3,14 +3,20 @@ import classNames from 'classnames';
 import { PPScopeClass } from 'content-scripts/settings';
 import styles from './Toast.scss';
 import { Icon } from 'react-icons-kit';
-import { check } from 'react-icons-kit/feather/check';
+import { check, x } from 'react-icons-kit/feather';
 import { changeNotification } from '../../../store/widgets/actions';
 import { connect } from 'react-redux';
+
+export enum ToastType {
+  success,
+  failure,
+}
 
 interface ToastProps {
   message: string;
   visible: boolean;
-  changeNotification: (visible: boolean, message?: string) => void;
+  type: ToastType;
+  changeNotification: (visible: boolean, message?: string, type?: ToastType) => void;
 }
 
 interface ToastState {
@@ -42,11 +48,31 @@ export default class Toast extends React.Component <Partial<ToastProps>, Partial
     setTimeout(() => this.props.changeNotification(false), 4000);
   }
 
+  getIcon() {
+    switch (this.props.type) {
+      case ToastType.failure:
+        return x;
+      case ToastType.success:
+      default:
+        return check;
+    }
+  }
+
   render() {
+    const { type } = this.props;
+
     return (
-      <div className={classNames(PPScopeClass, styles.self, { [styles.hidden]: !this.state.visible })}>
+      <div
+        className={classNames(
+          PPScopeClass,
+          styles.self, {
+            [styles.hidden]: !this.state.visible,
+            [styles.success]: type === ToastType.success,
+            [styles.failure]: type === ToastType.failure,
+          })}
+      >
         <div className={styles.iconBox}>
-          <Icon className={styles.icon} icon={check} size={26}/>
+          <Icon className={styles.icon} icon={this.getIcon()} size={26}/>
         </div>
         <div className={styles.message}>
           {this.props.message}

--- a/src/content-scripts/components/viewer/DeleteAnnotationModal.tsx
+++ b/src/content-scripts/components/viewer/DeleteAnnotationModal.tsx
@@ -10,6 +10,7 @@ import { PPScopeClass } from 'content-scripts/settings';
 import { setMouseOverViewer } from 'content-scripts/store/widgets/actions';
 import ppGA from 'common/pp-ga';
 import { selectAnnotation } from '../../store/api/selectors';
+import { changeNotification } from '../../store/widgets/actions';
 
 interface IModalProps {
   deleteModalId: string;
@@ -20,6 +21,7 @@ interface IModalProps {
   deleteAnnotation: (instance: AnnotationAPIModel) => Promise<object>;
   setMouseOverViewer: (value: boolean) => void;
   hideViewerDeleteModal: () => void;
+  changeNotification: (visible: boolean, message?: string) => void;
 }
 
 @connect(
@@ -40,6 +42,7 @@ interface IModalProps {
   {
     setMouseOverViewer,
     hideViewerDeleteModal,
+    changeNotification,
     deleteAnnotation: deleteResource,
   },
 )
@@ -50,6 +53,7 @@ export default class DeleteAnnotationModal extends React.Component<Partial<IModa
       .then(() => {
         const attrs = this.props.annotation.attributes;
         ppGA.annotationDeleted(this.props.annotation.id,  attrs.ppCategory, !attrs.comment, attrs.annotationLink);
+        this.props.changeNotification(true, 'Usunięto przypis');
       })
       .catch((errors) => {
         console.log(errors);

--- a/src/content-scripts/components/viewer/DeleteAnnotationModal.tsx
+++ b/src/content-scripts/components/viewer/DeleteAnnotationModal.tsx
@@ -11,6 +11,7 @@ import { setMouseOverViewer } from 'content-scripts/store/widgets/actions';
 import ppGA from 'common/pp-ga';
 import { selectAnnotation } from '../../store/api/selectors';
 import { changeNotification } from '../../store/widgets/actions';
+import { default as Toast, ToastType } from '../elements/Toast/Toast';
 
 interface IModalProps {
   deleteModalId: string;
@@ -21,7 +22,7 @@ interface IModalProps {
   deleteAnnotation: (instance: AnnotationAPIModel) => Promise<object>;
   setMouseOverViewer: (value: boolean) => void;
   hideViewerDeleteModal: () => void;
-  changeNotification: (visible: boolean, message?: string) => void;
+  changeNotification: (visible: boolean, message?: string, type?: ToastType) => void;
 }
 
 @connect(
@@ -53,10 +54,12 @@ export default class DeleteAnnotationModal extends React.Component<Partial<IModa
       .then(() => {
         const attrs = this.props.annotation.attributes;
         ppGA.annotationDeleted(this.props.annotation.id,  attrs.ppCategory, !attrs.comment, attrs.annotationLink);
-        this.props.changeNotification(true, 'Usunięto przypis');
+        this.props.changeNotification(true, 'Usunięto przypis', ToastType.success);
       })
       .catch((errors) => {
         console.log(errors);
+        this.props.changeNotification(true, 'Błąd! Nie udało się usunąć przypisu', ToastType.failure);
+        this.props.hideViewerDeleteModal();
       });
   }
 

--- a/src/content-scripts/store/widgets/actions.ts
+++ b/src/content-scripts/store/widgets/actions.ts
@@ -1,5 +1,6 @@
 import { Range as XPathRange } from 'xpath-range';
 import { AnnotationLocation } from '../../handlers/annotation-event-handlers';
+import { ToastType } from '../../components/elements/Toast/Toast';
 
 export const EDITOR_ANNOTATION = 'EDITOR_ANNOTATION';
 export const SET_EDITOR_SELECTION_RANGE = 'SET_EDITOR_SELECTION_RANGE';
@@ -129,12 +130,13 @@ export const changeViewerReportEditorOpen = (annotationId: string, isReportEdito
   };
 };
 
-export const changeNotification = (visible: boolean, message?: string) => {
+export const changeNotification = (visible: boolean, message?: string, type?: ToastType) => {
     return {
     type: NOTIFICATION_CHANGE,
     payload: {
       message,
       visible,
+      type,
     },
   };
 }


### PR DESCRIPTION
Resolves #271
Resolves #266 

- Make annotation menu hide on annotation mode turn off.
- Add annotation menu appearing when annotation mode is turned on and there is a selection in the document
- Success and failure toasts for all major requests in the app.