### PR TITLE
Major popup fixes

### DIFF
--- a/src/background/badge.ts
+++ b/src/background/badge.ts
@@ -1,5 +1,10 @@
 import { ILocationData } from 'common/store/tabs/tab/annotations/actions';
 
+export function setBadgeLocating(tabId) {
+  const text = '...';
+  chrome.browserAction.setBadgeText({ text, tabId });
+}
+
 export function syncBadgeWithAnnotations(locationData: ILocationData, tabId) {
   const count = locationData.located.length + locationData.unlocated.length;
   const text = count > 0 ? count.toString() : '';

--- a/src/common/api/annotation-requests.ts
+++ b/src/common/api/annotation-requests.ts
@@ -6,6 +6,8 @@ import { RangeAPIModel } from 'common/api/annotations';
 
 import { APICreateModel, APIModel } from './json-api';
 
+export const AnnotationRequestResourceType = 'annotationRequests';
+
 export interface AnnotationRequestCreateAttributes {
   url: string;
   quote?: string;

--- a/src/common/store/background-epics.ts
+++ b/src/common/store/background-epics.ts
@@ -61,7 +61,7 @@ export const annotationLocateEpic: StandardEpic = (action$, state$) => action$.p
 // TODO better return more than one action in annotationLocateEpic (not sure how to do it)
 export const annotationStageEpic: StandardEpic = (action$, state$) => action$.pipe(
   ofType(LOCATE_ANNOTATIONS),
-  map(action => {
+  map((action) => {
       const newAction = setAnnotationStage(AnnotationsStage.located);
       return syncTabMark(action, newAction);
     },
@@ -72,7 +72,7 @@ export const annotationStageEpic: StandardEpic = (action$, state$) => action$.pi
 export const annotationRequestLocateEpic: StandardEpic = (action$, state$) => action$.pipe(
   ofType('API_READ'),
   filter(action => getActionResourceType(action) === resourceTypes.ANNOTATION_REQUESTS),
-  mergeMap(action => defer(
+  mergeMap((action) => defer(
     async () => {
       const tabId = retrieveLogicalActionTab(action, state$.value.tabs);
       const locationData = await tabLocateAnnotations(tabId, action.payload.data);

--- a/src/common/store/tabs/tab/annotationRequests/actions.ts
+++ b/src/common/store/tabs/tab/annotationRequests/actions.ts
@@ -1,7 +1,10 @@
+import { AnnotationRequestsStage } from './types';
+
 import { ILocationData } from '../annotations/actions';
 
 export const LOCATE_ANNOTATION_REQUESTS = 'LOCATE_ANNOTATION_REQUESTS';
 export const LOCATE_CREATED_ANNOTATION_REQUESTS = 'LOCATE_CREATED_ANNOTATION_REQUESTS';
+export const SET_ANNOTATION_REQUEST_STAGE = 'SET_ANNOTATION_REQUEST_STAGE';
 
 export function locateAnnotationRequests({ located, unlocated }: ILocationData) {
   return {
@@ -19,6 +22,15 @@ export function locateCreatedAnnotationRequests({ located, unlocated }: ILocatio
     payload: {
       located,
       unlocated,
+    },
+  };
+}
+
+export function setAnnotationRequestStage(stage: AnnotationRequestsStage) {
+  return {
+    type: SET_ANNOTATION_REQUEST_STAGE,
+    payload: {
+      stage,
     },
   };
 }

--- a/src/common/store/tabs/tab/annotationRequests/reducers.ts
+++ b/src/common/store/tabs/tab/annotationRequests/reducers.ts
@@ -3,39 +3,38 @@ import { API_DELETED, API_READ } from 'redux-json-api/lib/constants';
 import * as resourceTypes from 'common/api/resource-types';
 import { getActionResourceType } from 'common/api/utils';
 
-import { LOCATE_ANNOTATION_REQUESTS, LOCATE_CREATED_ANNOTATION_REQUESTS } from './actions';
+import {
+  LOCATE_ANNOTATION_REQUESTS,
+  LOCATE_CREATED_ANNOTATION_REQUESTS,
+  SET_ANNOTATION_REQUEST_STAGE,
+} from './actions';
+import { AnnotationRequestsStage, AnnotationRequestsState } from './types';
 
-import { AnnotationsState } from '../annotations/types';
-
-const initialState: AnnotationsState = {
-  hasLoaded: false,
+const initialState: AnnotationRequestsState = {
+  stage: AnnotationRequestsStage.unloaded,
   located: [],
   unlocated: [],
 };
 
-export default function annotations(state = initialState, action): AnnotationsState {
+export default function annotations(state = initialState, action): AnnotationRequestsState {
   switch (action.type) {
+    case SET_ANNOTATION_REQUEST_STAGE:
+      return {
+        ...state,
+        stage: action.payload.stage,
+      };
     case LOCATE_ANNOTATION_REQUESTS:
       return {
         ...state,
         ...action.payload,
+        hasLoaded: true,
       };
     case LOCATE_CREATED_ANNOTATION_REQUESTS:
       return {
         ...state,
-        located: [ ...state.located, ...action.payload.located ],
-        unlocated: [ ...state.unlocated, ...action.payload.unlocated ],
+        located: [...state.located, ...action.payload.located],
+        unlocated: [...state.unlocated, ...action.payload.unlocated],
       };
-    case API_READ:
-      // save it in state when the annotation request endpoint has been read
-      if (getActionResourceType(action) === resourceTypes.ANNOTATION_REQUESTS) {
-        return {
-          ...state,
-          hasLoaded: true,
-        };
-      } else {
-        return state;
-      }
     case API_DELETED:
       if (getActionResourceType(action) === resourceTypes.ANNOTATION_REQUESTS) {
         const { id } = action.payload;

--- a/src/common/store/tabs/tab/annotationRequests/selectors.ts
+++ b/src/common/store/tabs/tab/annotationRequests/selectors.ts
@@ -1,21 +1,22 @@
 import { selectTab } from 'common/store/tabs/selectors';
 
-import { AnnotationAPIModel } from '../../../../api/annotations';
-import { selectAnnotation } from '../api/selectors';
 import { ITabState } from '../reducer';
+import { AnnotationRequestAPIModel } from '../../../../api/annotation-requests';
+import { selectAnnotationRequest } from '../api/selectors';
+import { AnnotationRequestsStage } from './types';
 
-export interface PopupAnnotationLocationData {
-  hasLoaded: boolean;
-  located: AnnotationAPIModel[];
-  unlocated: AnnotationAPIModel[];
+export interface PopupAnnotationRequestLocationData {
+  stage: AnnotationRequestsStage;
+  located: AnnotationRequestAPIModel[];
+  unlocated: AnnotationRequestAPIModel[];
 }
 
-export function selectAnnotationLocations(state: ITabState): PopupAnnotationLocationData {
-  const { located, unlocated, hasLoaded } = selectTab(state).annotations;
+export function selectAnnotationRequestLocations(state: ITabState): PopupAnnotationRequestLocationData {
+  const { located, unlocated, stage } = selectTab(state).annotationRequests;
   // Save annotation location data for usage in popup
   return {
-    hasLoaded,
-    located: located.map(location => selectAnnotation(state, location.annotationId)),
-    unlocated: unlocated.map(location => selectAnnotation(state, location.annotationId)),
+    stage,
+    located: located.map(location => selectAnnotationRequest(state, location.annotationId)),
+    unlocated: unlocated.map(location => selectAnnotationRequest(state, location.annotationId)),
   };
 }

--- a/src/common/store/tabs/tab/annotationRequests/selectors.ts
+++ b/src/common/store/tabs/tab/annotationRequests/selectors.ts
@@ -1,9 +1,10 @@
 import { selectTab } from 'common/store/tabs/selectors';
 
-import { ITabState } from '../reducer';
+import { AnnotationRequestsStage } from './types';
+
 import { AnnotationRequestAPIModel } from '../../../../api/annotation-requests';
 import { selectAnnotationRequest } from '../api/selectors';
-import { AnnotationRequestsStage } from './types';
+import { ITabState } from '../reducer';
 
 export interface PopupAnnotationRequestLocationData {
   stage: AnnotationRequestsStage;

--- a/src/common/store/tabs/tab/annotationRequests/types.ts
+++ b/src/common/store/tabs/tab/annotationRequests/types.ts
@@ -1,7 +1,13 @@
 import { Range as XPathRange } from 'xpath-range';
 
+export enum AnnotationRequestsStage {
+  unloaded,
+  loaded,
+  located,
+}
+
 export interface AnnotationRequestsState {
-  hasLoaded: boolean;
+  stage: AnnotationRequestsStage;
   located: LocatedAnnotationRequest[];
   unlocated: LocatedAnnotationRequest[];
 }

--- a/src/common/store/tabs/tab/annotationRequests/types.ts
+++ b/src/common/store/tabs/tab/annotationRequests/types.ts
@@ -1,9 +1,9 @@
 import { Range as XPathRange } from 'xpath-range';
 
 export enum AnnotationRequestsStage {
-  unloaded,
-  loaded,
-  located,
+  unloaded = 'unloaded',
+  loaded = 'loaded',
+  located = 'located',
 }
 
 export interface AnnotationRequestsState {

--- a/src/common/store/tabs/tab/annotations/actions.ts
+++ b/src/common/store/tabs/tab/annotations/actions.ts
@@ -1,7 +1,8 @@
-import { LocatedAnnotation } from './types';
+import { AnnotationsStage, LocatedAnnotation } from './types';
 
 export const LOCATE_ANNOTATIONS = 'LOCATE_ANNOTATIONS';
 export const LOCATE_CREATED_ANNOTATIONS = 'LOCATE_CREATED_ANNOTATIONS';
+export const SET_ANNOTATION_STAGE = 'SET_ANNOTATION_STAGE';
 
 export interface ILocationData {
   located: LocatedAnnotation[];
@@ -24,6 +25,15 @@ export function locateCreatedAnnotations({ located, unlocated }: ILocationData) 
     payload: {
       located,
       unlocated,
+    },
+  };
+}
+
+export function setAnnotationStage(stage: AnnotationsStage) {
+  return {
+    type: SET_ANNOTATION_STAGE,
+    payload: {
+      stage,
     },
   };
 }

--- a/src/common/store/tabs/tab/annotations/reducers.ts
+++ b/src/common/store/tabs/tab/annotations/reducers.ts
@@ -1,40 +1,36 @@
-import { API_DELETED, API_READ } from 'redux-json-api/lib/constants';
+import { API_DELETED } from 'redux-json-api/lib/constants';
 
 import * as resourceTypes from 'common/api/resource-types';
 import { getActionResourceType } from 'common/api/utils';
 
-import { LOCATE_ANNOTATIONS, LOCATE_CREATED_ANNOTATIONS } from './actions';
-import { AnnotationsState } from './types';
+import { LOCATE_ANNOTATIONS, LOCATE_CREATED_ANNOTATIONS, SET_ANNOTATION_STAGE } from './actions';
+import { AnnotationsStage, AnnotationsState } from './types';
 
 const initialState: AnnotationsState = {
-  hasLoaded: false,
+  stage: AnnotationsStage.unloaded,
   located: [],
   unlocated: [],
 };
 
 export default function annotations(state = initialState, action): AnnotationsState {
   switch (action.type) {
+    case SET_ANNOTATION_STAGE:
+      return {
+        ...state,
+        stage: action.payload.stage,
+      };
     case LOCATE_ANNOTATIONS:
       return {
         ...state,
         ...action.payload,
+        hasLoaded: true,
       };
     case LOCATE_CREATED_ANNOTATIONS:
       return {
         ...state,
-        located: [ ...state.located, ...action.payload.located ],
-        unlocated: [ ...state.unlocated, ...action.payload.unlocated ],
+        located: [...state.located, ...action.payload.located],
+        unlocated: [...state.unlocated, ...action.payload.unlocated],
       };
-    case API_READ:
-      // save it in state when the annotation endpoint has been read
-      if (getActionResourceType(action) === resourceTypes.ANNOTATIONS) {
-        return {
-          ...state,
-          hasLoaded: true,
-        };
-      } else {
-        return state;
-      }
     case API_DELETED:
       if (getActionResourceType(action) === resourceTypes.ANNOTATIONS) {
         const { id } = action.payload;

--- a/src/common/store/tabs/tab/annotations/selectors.ts
+++ b/src/common/store/tabs/tab/annotations/selectors.ts
@@ -1,20 +1,22 @@
 import { selectTab } from 'common/store/tabs/selectors';
 
+import { AnnotationsStage } from './types';
+
 import { AnnotationAPIModel } from '../../../../api/annotations';
 import { selectAnnotation } from '../api/selectors';
 import { ITabState } from '../reducer';
 
 export interface PopupAnnotationLocationData {
-  hasLoaded: boolean;
+  stage: AnnotationsStage;
   located: AnnotationAPIModel[];
   unlocated: AnnotationAPIModel[];
 }
 
 export function selectAnnotationLocations(state: ITabState): PopupAnnotationLocationData {
-  const { located, unlocated, hasLoaded } = selectTab(state).annotations;
+  const { located, unlocated, stage } = selectTab(state).annotations;
   // Save annotation location data for usage in popup
   return {
-    hasLoaded,
+    stage,
     located: located.map(location => selectAnnotation(state, location.annotationId)),
     unlocated: unlocated.map(location => selectAnnotation(state, location.annotationId)),
   };

--- a/src/common/store/tabs/tab/annotations/types.ts
+++ b/src/common/store/tabs/tab/annotations/types.ts
@@ -1,7 +1,13 @@
 import { Range as XPathRange } from 'xpath-range';
 
+export enum AnnotationsStage {
+  unloaded,
+  loaded,
+  located,
+}
+
 export interface AnnotationsState {
-  hasLoaded: boolean;
+  stage: AnnotationsStage;
   located: LocatedAnnotation[];
   unlocated: LocatedAnnotation[];
 }

--- a/src/common/store/tabs/tab/annotations/types.ts
+++ b/src/common/store/tabs/tab/annotations/types.ts
@@ -1,9 +1,9 @@
 import { Range as XPathRange } from 'xpath-range';
 
 export enum AnnotationsStage {
-  unloaded,
-  loaded,
-  located,
+  unloaded = 'unloaded',
+  loaded = 'loaded',
+  located = 'located',
 }
 
 export interface AnnotationsState {

--- a/src/content-scripts/components/App.tsx
+++ b/src/content-scripts/components/App.tsx
@@ -13,6 +13,7 @@ import SideWidget from './elements/SideWidget/SideWidget';
 import Toast from './elements/Toast/Toast';
 import Menu from './menu/index';
 import ViewerManager from './viewer/ViewerManager';
+
 import { IAnnotationFormState, IAnnotationRequestFormState } from '../../common/store/tabs/tab/widgets';
 
 interface AppProps {

--- a/src/content-scripts/components/viewer/Viewer.tsx
+++ b/src/content-scripts/components/viewer/Viewer.tsx
@@ -15,7 +15,10 @@ import {
 import DeleteAnnotationModal from './DeleteAnnotationModal';
 import styles from './Viewer.scss';
 import ViewerItem from './ViewerItem';
+
+import { AnnotationResourceType } from '../../../common/api/annotations';
 import Timer = NodeJS.Timer;
+import { resourceToHighlightId } from '../../utils/Highlighter';
 
 interface IViewerProps {
   locationX: number;
@@ -93,7 +96,8 @@ export default class Viewer extends React.Component<Partial<IViewerProps>, {}> {
         [${PPHighlightIdAttr}]:hover
       `).forEach((node) => {
         for (const annotationId of this.props.annotationIds) {
-          if (node.matches(`[${PPHighlightIdAttr}="annotation:${annotationId}"]`)) {
+          const highlightId = resourceToHighlightId(AnnotationResourceType, annotationId);
+          if (node.matches(`[${PPHighlightIdAttr}="${highlightId}"]`)) {
             mouseOver = true;
           }
         }

--- a/src/content-scripts/main.tsx
+++ b/src/content-scripts/main.tsx
@@ -32,6 +32,10 @@ import appComponent from './modules/app-component';
 import highlightManager from './modules/highlight-manager';
 import store from './store';
 
+import { setAnnotationRequestStage } from '../common/store/tabs/tab/annotationRequests/actions';
+import { AnnotationRequestsStage, AnnotationRequestsState } from '../common/store/tabs/tab/annotationRequests/types';
+import { setAnnotationStage } from '../common/store/tabs/tab/annotations/actions';
+import { AnnotationsStage } from '../common/store/tabs/tab/annotations/types';
 import '../css/common/base.scss';
 
 // New defaults/modifiers for some semantic-ui components
@@ -113,6 +117,8 @@ async function initData() {
   } catch (err) {
     console.debug(`Failed to fetch annotations: ${err.toString()}`);
     Sentry.captureException(err);
+  } finally {
+    store.dispatch(setAnnotationStage(AnnotationsStage.loaded));
   }
 
   try {
@@ -122,6 +128,8 @@ async function initData() {
   } catch (err) {
     console.debug(`Failed to fetch annotation requests: ${err.toString()}`);
     Sentry.captureException(err);
+  } finally {
+    store.dispatch(setAnnotationRequestStage(AnnotationRequestsStage.loaded));
   }
 }
 

--- a/src/content-scripts/main.tsx
+++ b/src/content-scripts/main.tsx
@@ -146,8 +146,10 @@ async function initUI() {
   // Injecting React components into DOM
   appComponent.init();
 
-  // Saving the annotation location information to DOM for reads in selenium + in console
-  annotationLocationNotifier.init();
+  if (PPSettings.DEV) {
+    // Saving the annotation location information to DOM for reads in selenium + in console
+    annotationLocationNotifier.init();
+  }
   // Rendering annotations in DOM
   highlightManager.init();
 }

--- a/src/content-scripts/utils/Highlighter.ts
+++ b/src/content-scripts/utils/Highlighter.ts
@@ -2,6 +2,9 @@ import $ from 'jquery';
 import { Range as XPathRange } from 'xpath-range';
 
 import { PPHighlightClass, PPHighlightIdAttr } from 'content-scripts/settings';
+import { AnnotationResourceType } from '../../common/api/annotations';
+import { APIModel } from '../../common/api/json-api';
+import { AnnotationRequestResourceType } from '../../common/api/annotation-requests';
 
 /**
  * highlightRange wraps the DOM Nodes within the provided range with a highlight
@@ -231,7 +234,7 @@ export default class Highlighter {
     delete this.highlightRegistry[normedId];
   }
 
-  scrollToAnnotation = (id: number | string) => {
+  scrollToHighlight = (id: number | string) => {
     const normedId = Highlighter.coerceId(id);
     const data = this.highlightRegistry[normedId];
     // Take an arbitrary first span (there are hardly any multiline annotations anyway)
@@ -266,3 +269,26 @@ export default class Highlighter {
       });
   }
 }
+
+
+
+// tslint:disable-next-line:no-shadowed-variable
+export function instanceToHighlightId(instance: APIModel) {
+  /*
+   * Get unique id for an instance of an object that should be highlighted in text
+   * Highlighter indexes highlighted objects by id
+   */
+  return resourceToHighlightId(instance.type, instance.id);
+}
+
+export function resourceToHighlightId(resourceType: string, id: string) {
+  const allowedTypes = [AnnotationResourceType, AnnotationRequestResourceType];
+  if (allowedTypes.indexOf(resourceType) === -1) {
+    throw new Error(
+      `Generating unique highlighter id for an instance that cannot be highlighted (type: ${resourceType})`,
+    );
+  }
+  return resourceToUniqueId(resourceType, id);
+}
+
+const resourceToUniqueId = (resourceType: string, id: string) => `${resourceType}:${id}`;

--- a/src/popup/components/BrowserPopup.tsx
+++ b/src/popup/components/BrowserPopup.tsx
@@ -26,18 +26,18 @@ import { PopupPages } from './BrowserPopupNavigator';
 import LogoutPanel from './LogoutPanel';
 import Toggle from './toggle/Toggle';
 
-import '../css/popup.scss';
-import {
-  PopupAnnotationLocationData,
-  selectAnnotationLocations
-} from '../../common/store/tabs/tab/annotations/selectors';
 import {
   PopupAnnotationRequestLocationData,
-  selectAnnotationRequestLocations
+  selectAnnotationRequestLocations,
 } from '../../common/store/tabs/tab/annotationRequests/selectors';
-import { ITabInfoState } from '../../common/store/tabs/tab/tabInfo';
-import { AnnotationsStage } from '../../common/store/tabs/tab/annotations/types';
 import { AnnotationRequestsStage } from '../../common/store/tabs/tab/annotationRequests/types';
+import {
+  PopupAnnotationLocationData,
+  selectAnnotationLocations,
+} from '../../common/store/tabs/tab/annotations/selectors';
+import { AnnotationsStage } from '../../common/store/tabs/tab/annotations/types';
+import { ITabInfoState } from '../../common/store/tabs/tab/tabInfo';
+import '../css/popup.scss';
 
 export interface IBrowserPopupProps {
   user: IUserState;
@@ -200,7 +200,6 @@ export default class BrowserPopup extends React.Component<Partial<IBrowserPopupP
       }
     }
   }
-
 
   isAnnotationRequestButtonEnabled = () => {
     const {

--- a/src/popup/components/annotationList/AnnotationList.tsx
+++ b/src/popup/components/annotationList/AnnotationList.tsx
@@ -13,8 +13,10 @@ import { standardizeUrlForPageSettings } from 'common/url';
 import styles from './AnnotationList.scss';
 
 import { AnnotationsStage } from '../../../common/store/tabs/tab/annotations/types';
-import { sendScrollToAnnotation } from '../../messages';
+import { sendScrollToHighlight } from '../../messages';
 import { PopupPages } from '../BrowserPopupNavigator';
+import { AnnotationResourceType } from '../../../common/api/annotations';
+import { resourceToHighlightId } from '../../../content-scripts/utils/Highlighter';
 
 export interface IAnnotationListProps {
   annotations: PopupAnnotationLocationData;
@@ -53,7 +55,7 @@ export default class AnnotationList extends React.Component<Partial<IAnnotationL
 
   onAnnotationClick = (e) => {
     const { annotationId } = e.currentTarget.dataset;
-    sendScrollToAnnotation(annotationId);
+    sendScrollToHighlight(resourceToHighlightId(AnnotationResourceType, annotationId));
 
     // TODO: such tabs query already takes in BrowserPopup component, pass those data using store to be DRY
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {

--- a/src/popup/components/annotationList/AnnotationList.tsx
+++ b/src/popup/components/annotationList/AnnotationList.tsx
@@ -12,6 +12,7 @@ import { standardizeUrlForPageSettings } from 'common/url';
 
 import styles from './AnnotationList.scss';
 
+import { AnnotationsStage } from '../../../common/store/tabs/tab/annotations/types';
 import { sendScrollToAnnotation } from '../../messages';
 import { PopupPages } from '../BrowserPopupNavigator';
 
@@ -63,7 +64,7 @@ export default class AnnotationList extends React.Component<Partial<IAnnotationL
   }
 
   render() {
-    if (!this.props.annotations.hasLoaded) {
+    if (this.props.annotations.stage !== AnnotationsStage.located) {
       return (
         <div className={styles.self}>
           Ładuję...

--- a/src/popup/components/annotationSummary/AnnotationSummary.tsx
+++ b/src/popup/components/annotationSummary/AnnotationSummary.tsx
@@ -14,6 +14,8 @@ import { ITabInfoState } from 'common/store/tabs/tab/tabInfo';
 
 import styles from './AnnotationSummary.scss';
 
+import { AnnotationsStage } from '../../../common/store/tabs/tab/annotations/types';
+
 export interface IAnnotationSummaryProps {
   tabInfo: ITabInfoState;
   annotations: PopupAnnotationLocationData;
@@ -87,6 +89,8 @@ export default class AnnotationSummary extends React.Component<Partial<IAnnotati
       contentScriptWontLoad,
     } = this.props.tabInfo;
 
+    const { stage } = this.props.annotations;
+
     let message;
     if (isSupported !== null && !isSupported) {
       message = notSupportedMessage;
@@ -95,8 +99,10 @@ export default class AnnotationSummary extends React.Component<Partial<IAnnotati
         'Jeśli uważasz, że PP powinien obsługiwać tę stronę, daj nam znać!';
     } else if (!contentScriptLoaded) {
       message = 'Łączę się ze stroną...';
-    } else if (!this.props.annotations.hasLoaded) {
+    } else if (stage === AnnotationsStage.unloaded) {
       message = 'Ładuję przypisy...';
+    } else if (stage === AnnotationsStage.loaded) {
+      message = 'Lokalizuję przypisy...';
     }
     if (message) {
       return (

--- a/src/popup/css/popup.scss
+++ b/src/popup/css/popup.scss
@@ -6,6 +6,7 @@
 
 html, body {
   height: 171px;
+  margin: 0;
   border: none;
   border-color: rgba(0, 0, 0, 0.08);
   font-family: 'Roboto', sans-serif;

--- a/src/popup/messages.ts
+++ b/src/popup/messages.ts
@@ -26,12 +26,12 @@ export function waitUntilContentScriptShouldHaveConnected(tabId): Promise<null> 
   );
 }
 
-export function sendScrollToAnnotation(annotationId: string) {
+export function sendScrollToHighlight(highlightId: string) {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     chrome.tabs.sendMessage(tabs[0].id,
       {
-        action: 'SCROLL_TO_ANNOTATION',
-        payload: { annotationId },
+        action: 'SCROLL_TO_HIGHLIGHT',
+        payload: { highlightId },
       });
   });
 }


### PR DESCRIPTION
Merge after #358 (changes are basically independent, but there are some import conflicts)

- fix popup message "no annotation" appearing to early
- more detailed loading stage information in store
- corresponding loading stages of annotation requests
- different badge appearing during annotation location
- fix details of popup menu buttons clickability

As noted in the comments, two epics are now a bit redundant but I didn't want to focus on how to achieve the same in a more elegant way (with a lot of work still ahead of us...)